### PR TITLE
Update FirebaseRemoteConfigHelper to use Firebase Remote Config for base URL

### DIFF
--- a/lib/core/helpers/firebase_remote_config_helper.dart
+++ b/lib/core/helpers/firebase_remote_config_helper.dart
@@ -1,0 +1,52 @@
+import 'dart:developer';
+
+import 'package:firebase_remote_config/firebase_remote_config.dart';
+import 'package:medina_stores/core/networking/api_constants.dart';
+
+class FirebaseRemoteConfigKeys {
+  static const String baseUrl = 'base_url';
+}
+
+class FirebaseRemoteConfigHelper {
+  FirebaseRemoteConfigHelper._() : _remoteConfig = FirebaseRemoteConfig.instance;
+
+  static FirebaseRemoteConfigHelper instance = FirebaseRemoteConfigHelper._();
+  factory FirebaseRemoteConfigHelper() => instance;
+
+  final FirebaseRemoteConfig _remoteConfig;
+
+  String getString(String key) => _remoteConfig.getString(key);
+  bool getBool(String key) => _remoteConfig.getBool(key);
+  int getInt(String key) => _remoteConfig.getInt(key);
+  double getDouble(String key) => _remoteConfig.getDouble(key);
+
+  final remoteConfigSettings = RemoteConfigSettings(
+    fetchTimeout: const Duration(minutes: 1),
+    minimumFetchInterval: const Duration(seconds: 1),
+  );
+
+  Future<void> _setConfigSettings() async => _remoteConfig.setConfigSettings(remoteConfigSettings);
+
+  Future<void> _setDefaults() async => _remoteConfig.setDefaults(
+        const {
+          FirebaseRemoteConfigKeys.baseUrl: ApiConstants.BASE_URL,
+        },
+      );
+
+  Future<void> fetchAndActivate() async {
+    bool updated = await _remoteConfig.fetchAndActivate();
+    if (!updated) {
+      log('The config is not updated..');
+      return;
+    }
+    log('The config has been updated.');
+  }
+
+  Future<void> initialize() async {
+    await _setConfigSettings();
+    await _setDefaults();
+    await fetchAndActivate();
+  }
+
+  String get baseUrl => getString(FirebaseRemoteConfigKeys.baseUrl);
+}

--- a/lib/core/networking/dio_service.dart
+++ b/lib/core/networking/dio_service.dart
@@ -4,6 +4,7 @@ import 'package:dio/dio.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:medina_stores/core/helpers/firebase_remote_config_helper.dart';
 import 'package:medina_stores/core/navigation/navigator.dart';
 
 import '../../config/resources/languages.dart';
@@ -25,7 +26,7 @@ class DioService implements ApiService {
 
   void _initDio() {
     _dio = Dio()
-      ..options.baseUrl = ApiConstants.BASE_URL
+      ..options.baseUrl = FirebaseRemoteConfigHelper.instance.baseUrl
       ..options.connectTimeout = const Duration(
         seconds: ApiConstants.connectTimeoutDurationInSeconds,
       )

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:medina_stores/core/helpers/firebase_remote_config_helper.dart';
 import 'package:medina_stores/core/utils/user_utils.dart';
 import 'package:medina_stores/features/theme/presentation/cubit/theme_cubit.dart';
 
@@ -26,6 +27,8 @@ void main() async {
     EasyLocalization.ensureInitialized(),
     CacheHelper.init(),
   ]);
+
+  await FirebaseRemoteConfigHelper.instance.initialize();
 
   DependencyHelper.instance.registerDependencies();
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -473,6 +473,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.8.12"
+  firebase_remote_config:
+    dependency: "direct main"
+    description:
+      name: firebase_remote_config
+      sha256: "62e86ed64370c382a2f872fbcabcae591c404776eb84685eb535bab53c0c00d5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.4"
+  firebase_remote_config_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_remote_config_platform_interface
+      sha256: "80973fa763b7c9a0fc0596afed7063f2378de2cf2d37b017254e613160b43135"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.40"
+  firebase_remote_config_web:
+    dependency: transitive
+    description:
+      name: firebase_remote_config_web
+      sha256: "14ba362bdcf7abda12fa9060f2ebae7d342153e4d619007071e98cd557ce29a3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.12"
   fixnum:
     dependency: transitive
     description:
@@ -993,18 +1017,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -1049,10 +1073,10 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.8.0"
   measure_size:
     dependency: transitive
     description:
@@ -1065,10 +1089,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -1478,10 +1502,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.0"
   time:
     dependency: transitive
     description:
@@ -1670,10 +1694,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.1"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -94,6 +94,7 @@ dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^3.0.0
+  firebase_remote_config: ^5.0.4
 
 dev_dependencies:
   build_runner:


### PR DESCRIPTION
This pull request updates the `FirebaseRemoteConfigHelper` class to use Firebase Remote Config for the base URL. It introduces a new method `initialize()` that sets the config settings, sets defaults, and fetches and activates the config. The `DioService` and the main function in the app are updated to use the base URL from the `FirebaseRemoteConfigHelper` instance. The necessary dependencies for Firebase Remote Config are also added to the `pubspec.yaml` file.