### PR TITLE
Refactor dependencies and providers in layout and main pages

### DIFF
--- a/lib/features/layout/presentation/pages/layout_page.dart
+++ b/lib/features/layout/presentation/pages/layout_page.dart
@@ -5,8 +5,15 @@ class LayoutPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider(
-      create: (context) => DependencyHelper.instance.get<LayoutCubit>(),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider(
+          create: (context) => DependencyHelper.instance.get<LayoutCubit>(),
+        ),
+        BlocProvider(
+          create: (context) => DependencyHelper.instance.get<AdCubit>()..getAds(),
+        ),
+      ],
       child: const LayoutPageBody(),
     );
   }

--- a/lib/features/layout/presentation/presentation_imports.dart
+++ b/lib/features/layout/presentation/presentation_imports.dart
@@ -1,6 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:medina_stores/features/ad/presentation/presentation_imports.dart';
 import 'package:medina_stores/features/main/presentation/presentation_imports.dart';
 import 'package:medina_stores/features/profile/presentation/presentation_imports.dart';
 

--- a/lib/features/main/presentation/pages/main_tab_page.dart
+++ b/lib/features/main/presentation/pages/main_tab_page.dart
@@ -5,15 +5,8 @@ class MainTab extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MultiBlocProvider(
-      providers: [
-        BlocProvider(
-          create: (context) => DependencyHelper.instance.get<MainCubit>(),
-        ),
-        BlocProvider(
-          create: (context) => DependencyHelper.instance.get<AdCubit>()..getAds(),
-        ),
-      ],
+    return BlocProvider(
+      create: (context) => DependencyHelper.instance.get<MainCubit>(),
       child: const MainTabPageBody(),
     );
   }
@@ -25,11 +18,7 @@ class MainTabPageBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: MainAppBar(
-        title: Text(LocaleKeys.home.tr()),
-        padEnd: false,
-        actions: const [ThemeIconButton()],
-      ),
+      appBar: MainAppBar(title: Text(LocaleKeys.home.tr())),
       body: Padding(
         padding: REdgeInsets.symmetric(vertical: 16),
         child: const Column(

--- a/lib/features/main/presentation/presentation_imports.dart
+++ b/lib/features/main/presentation/presentation_imports.dart
@@ -9,7 +9,6 @@ import 'package:medina_stores/features/ad/presentation/presentation_imports.dart
 
 import '../../../core/helpers/dependency_helper.dart';
 import '../../../core/shared_widgets/core_widgets/main_app_bar.dart';
-import '../../../core/shared_widgets/theme_icon_button.dart';
 
 part '../presentation/cubit/main_cubit.dart';
 part '../presentation/cubit/main_state.dart';

--- a/lib/features/user/presentation/pages/login_page.dart
+++ b/lib/features/user/presentation/pages/login_page.dart
@@ -28,18 +28,7 @@ class _LoginPageState extends State<LoginPage> {
         selector: (state) => (status: state.loginStatus, failure: state.loginFailure),
         builder: (context, state) {
           return Scaffold(
-            appBar: MainAppBar(
-              actions: [
-                IconButton(
-                  icon: Icon(
-                    context.isDark() ? Icons.light_mode_outlined : Icons.dark_mode_outlined,
-                  ),
-                  onPressed: () {
-                    context.toggleTheme(false);
-                  },
-                ),
-              ],
-            ),
+            appBar: const MainAppBar(),
             body: Padding(
               padding: REdgeInsets.symmetric(horizontal: 16.0),
               child: Column(


### PR DESCRIPTION
This pull request includes changes to refactor the dependencies and providers in the layout and main pages. The `LayoutPage` and `MainTab` classes have been updated to use `MultiBlocProvider` instead of `BlocProvider` to provide multiple blocs. Additionally, the `MainTabPageBody` and `_LoginPageState` classes have been updated to remove unnecessary code related to the app bar and theme button.