### PR TITLE
Refactor category and subcategory repositories and usecases

### DIFF
--- a/lib/core/helpers/dependency_helper.dart
+++ b/lib/core/helpers/dependency_helper.dart
@@ -1,4 +1,6 @@
 import 'package:get_it/get_it.dart';
+import '../../features/sub_category/di/setup_sub_category_dependencies.dart';
+import '../../features/category/di/setup_category_dependencies.dart';
 
 import '../../features/ad/di/setup_ad_dependencies.dart';
 import '../../features/layout/di/setup_layout_dependencies.dart';
@@ -18,6 +20,8 @@ class DependencyHelper {
 
   void registerDependencies() {
     setUpGeneralDependencies();
+    setUpSubCategoryDependencies();
+    setUpCategoryDependencies();
     setUpAdDependencies();
     setUpProfileDependencies();
     setUpOrderDependencies();

--- a/lib/core/helpers/firebase_remote_config_helper.dart
+++ b/lib/core/helpers/firebase_remote_config_helper.dart
@@ -4,7 +4,7 @@ import 'package:firebase_remote_config/firebase_remote_config.dart';
 import 'package:medina_stores/core/networking/api_constants.dart';
 
 class FirebaseRemoteConfigKeys {
-  static const String baseUrl = 'base_url';
+  static const String domain = 'domain';
 }
 
 class FirebaseRemoteConfigHelper {
@@ -29,7 +29,7 @@ class FirebaseRemoteConfigHelper {
 
   Future<void> _setDefaults() async => _remoteConfig.setDefaults(
         const {
-          FirebaseRemoteConfigKeys.baseUrl: ApiConstants.BASE_URL,
+          FirebaseRemoteConfigKeys.domain: ApiConstants.domain,
         },
       );
 
@@ -48,5 +48,5 @@ class FirebaseRemoteConfigHelper {
     await fetchAndActivate();
   }
 
-  String get baseUrl => getString(FirebaseRemoteConfigKeys.baseUrl);
+  String get domain => getString(FirebaseRemoteConfigKeys.domain);
 }

--- a/lib/core/networking/api_constants.dart
+++ b/lib/core/networking/api_constants.dart
@@ -1,7 +1,12 @@
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 
+import 'package:medina_stores/core/helpers/firebase_remote_config_helper.dart';
+
 class ApiConstants {
-  static const String BASE_URL = 'https://madinastores-0222f46c261b.herokuapp.com/api/mobile';
+  static const String domain = 'http://api-staging.madinastores.xyz';
+  static const String path = 'api/mobile';
+  static String BASE_URL = '${FirebaseRemoteConfigHelper.instance.domain}/$path';
+
   static const int connectTimeoutDurationInSeconds = 30;
   static const int recieveTimeoutDuration = 30;
   static ApiEndPoints endPoints = ApiEndPoints();
@@ -10,6 +15,9 @@ class ApiConstants {
 class ApiEndPoints {
   // Home
   final String ADS = '/home/sliders';
+  final String CATEGORIES = '/home/categories';
+  final String SUB_CATEGORIES = '/sub-categories';
+
   // Auth
   final String login = '/login';
   final String register = '/register';

--- a/lib/core/networking/dio_service.dart
+++ b/lib/core/networking/dio_service.dart
@@ -4,7 +4,6 @@ import 'package:dio/dio.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:medina_stores/core/helpers/firebase_remote_config_helper.dart';
 import 'package:medina_stores/core/navigation/navigator.dart';
 
 import '../../config/resources/languages.dart';
@@ -26,7 +25,7 @@ class DioService implements ApiService {
 
   void _initDio() {
     _dio = Dio()
-      ..options.baseUrl = FirebaseRemoteConfigHelper.instance.baseUrl
+      ..options.baseUrl = ApiConstants.BASE_URL
       ..options.connectTimeout = const Duration(
         seconds: ApiConstants.connectTimeoutDurationInSeconds,
       )

--- a/lib/core/shared_widgets/core_widgets/image_widget.dart
+++ b/lib/core/shared_widgets/core_widgets/image_widget.dart
@@ -39,7 +39,7 @@ class ImageWidget extends StatelessWidget {
           ShimmerWidget.horizontal(
             width: width,
             height: height,
-            borderRadius: borderRadius,
+            borderRadius: shape == BoxShape.circle ? BorderRadius.circular(50) : borderRadius,
           ),
           Center(
             child: Icon(
@@ -54,7 +54,7 @@ class ImageWidget extends StatelessWidget {
   Widget get placeHolder => ShimmerWidget.horizontal(
         width: width,
         height: height,
-        borderRadius: borderRadius,
+        borderRadius: shape == BoxShape.circle ? BorderRadius.circular(50) : borderRadius,
       );
 
   Widget get imageWidget => CachedNetworkImage(
@@ -67,6 +67,7 @@ class ImageWidget extends StatelessWidget {
           width: width,
           decoration: BoxDecoration(
             borderRadius: borderRadius,
+            shape: shape,
             image: DecorationImage(
               image: imageProvider,
               fit: BoxFit.cover,

--- a/lib/core/standards/drop_down_item.dart
+++ b/lib/core/standards/drop_down_item.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+
+import 'package:equatable/equatable.dart';
+
+class DropdownItem extends Equatable {
+  final int id;
+  final String name;
+
+  const DropdownItem({required this.id, required this.name});
+
+  @override
+  List<Object?> get props => [id, name];
+}
+
+class DropdownItemModel extends DropdownItem {
+  const DropdownItemModel({required super.id, required super.name});
+
+  factory DropdownItemModel.fromMap(Map<String, dynamic> json) {
+    return DropdownItemModel(
+      id: json['id'],
+      name: json['name'],
+    );
+  }
+
+  factory DropdownItemModel.fromJson(String source) => DropdownItemModel.fromMap(json.decode(source));
+
+  Map<String, dynamic> toMap() => {'id': id, 'name': name};
+
+  String toJson() => json.encode(toMap());
+}

--- a/lib/core/standards/response_model.dart
+++ b/lib/core/standards/response_model.dart
@@ -31,7 +31,7 @@ class ApiResponse<T extends Object?> extends Equatable {
       data: T == Null
           ? null
           : mapper != null
-              ? mapper(map['data'])
+              ? mapper(map)
               : map['data'],
       isSuceess: map['success'],
     );
@@ -45,12 +45,7 @@ class ApiResponse<T extends Object?> extends Equatable {
       errors: data?['errors'] == null
           ? []
           : List<MapEntry<String, List<String>>>.from(
-              data?['errors'].entries.map(
-                    (e) => MapEntry<String, List<String>>(
-                      e.key,
-                      List<String>.from(e.value),
-                    ),
-                  ),
+              (data!['errors'] as Map<String, List<String>>).entries,
             ),
     );
   }

--- a/lib/features/ad/data/datasources/ad_remote_data_source.dart
+++ b/lib/features/ad/data/datasources/ad_remote_data_source.dart
@@ -17,7 +17,7 @@ class AdRemoteDataSourceImpl implements AdRemoteDataSource {
           request,
           mapper: (json) => ApiResponse.fromMapSuccess(
             json,
-            mapper: (data) => PaginatedList.fromMap(data, mapper: (x) => AdModel.fromMap(x)),
+            mapper: (data) => PaginatedList.fromMap(data['data'], mapper: (x) => AdModel.fromMap(x)),
           ),
         );
   }

--- a/lib/features/category/data/data_imports.dart
+++ b/lib/features/category/data/data_imports.dart
@@ -1,0 +1,17 @@
+import 'dart:convert';
+
+import 'package:dartz/dartz.dart';
+import 'package:intl/intl.dart';
+import 'package:medina_stores/core/networking/api_constants.dart';
+
+import '../../../../core/helpers/dependency_helper.dart';
+import '../../../../core/networking/api_request.dart';
+import '../../../../core/networking/api_service.dart';
+import '../../../core/error/failures.dart';
+import '../../../core/extensions/error_handler_extension.dart';
+import '../../../core/standards/response_model.dart';
+import '../domain/domain_imports.dart';
+
+part '../data/datasources/category_remote_data_source.dart';
+part '../data/models/category_model.dart';
+part '../data/repositories/category_repository_impl.dart';

--- a/lib/features/category/data/datasources/category_remote_data_source.dart
+++ b/lib/features/category/data/datasources/category_remote_data_source.dart
@@ -1,0 +1,41 @@
+part of '../data_imports.dart';
+
+abstract class CategoryRemoteDataSource {
+  Future<ApiResponse<List<CategoryModel>>> get getCategories;
+  Future<ApiResponse<CategoryModel>> addCategory(AddCategoryParams params);
+}
+
+class CategoryRemoteDataSourceImpl implements CategoryRemoteDataSource {
+  @override
+  Future<ApiResponse<List<CategoryModel>>> get getCategories async {
+    final request = ApiRequest(
+      method: RequestMethod.get,
+      path: ApiConstants.endPoints.CATEGORIES,
+    );
+
+    return await DependencyHelper.instance.get<ApiService>().callApi<List<CategoryModel>>(
+          request,
+          mapper: (json) => ApiResponse.fromMapSuccess(
+            json,
+            mapper: (data) => List<CategoryModel>.from(data['data'].map((x) => CategoryModel.fromMap(x))),
+          ),
+        );
+  }
+
+  @override
+  Future<ApiResponse<CategoryModel>> addCategory(AddCategoryParams params) async {
+    final request = ApiRequest(
+      method: RequestMethod.post,
+      path: "/dashboard/branches",
+      body: params.toMap(),
+    );
+
+    return await DependencyHelper.instance.get<ApiService>().callApi<CategoryModel>(
+          request,
+          mapper: (json) => ApiResponse.fromMapSuccess(
+            json,
+            mapper: (data) => CategoryModel.fromMap(data),
+          ),
+        );
+  }
+}

--- a/lib/features/category/data/models/category_model.dart
+++ b/lib/features/category/data/models/category_model.dart
@@ -1,0 +1,41 @@
+part of '../data_imports.dart';
+
+class CategoryModel extends Category {
+  const CategoryModel({
+    required super.id,
+    required super.name,
+    super.parent,
+    required super.active,
+    required super.slug,
+    required super.image,
+    required super.createdAt,
+  });
+
+  factory CategoryModel.fromMap(Map<String, dynamic> map) {
+    return CategoryModel(
+      id: map['id'],
+      name: map['name'],
+      parent: map['parent'],
+      active: map['active'],
+      slug: map['slug'],
+      image: map['image'],
+      createdAt: DateFormat('yyyy MMM dd hh:mm:ss').parse(map['created_at']),
+    );
+  }
+
+  factory CategoryModel.fromJson(String source) => CategoryModel.fromMap(json.decode(source));
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'name': name,
+      'parent': parent,
+      'active': active,
+      'slug': slug,
+      'image': image,
+      'created_at': DateFormat('yyyy MMM dd hh:mm:ss').format(createdAt),
+    };
+  }
+
+  String toJson() => json.encode(toMap());
+}

--- a/lib/features/category/data/repositories/category_repository_impl.dart
+++ b/lib/features/category/data/repositories/category_repository_impl.dart
@@ -1,0 +1,17 @@
+part of '../data_imports.dart';
+
+class CategoryRepositoryImpl implements CategoryRepository {
+  final CategoryRemoteDataSource remoteDataSource;
+
+  const CategoryRepositoryImpl({required this.remoteDataSource});
+
+  @override
+  Future<Either<Failure, ApiResponse<List<Category>>>> getCategories() async {
+    return await remoteDataSource.getCategories.handleCallbackWithFailure;
+  }
+
+  @override
+  Future<Either<Failure, ApiResponse<Category>>> addCategory(AddCategoryParams params) async {
+    return await remoteDataSource.addCategory(params).handleCallbackWithFailure;
+  }
+}

--- a/lib/features/category/di/setup_category_dependencies.dart
+++ b/lib/features/category/di/setup_category_dependencies.dart
@@ -1,0 +1,33 @@
+import '../../../core/helpers/dependency_helper.dart';
+import '../data/data_imports.dart';
+import '../domain/domain_imports.dart';
+import '../presentation/presentation_imports.dart';
+
+void setUpCategoryDependencies() async {
+  // CUBIT
+  DependencyHelper.instance.serviceLocator.registerFactory(
+    () => CategoryCubit(
+      getCategoriesUsecase: DependencyHelper.instance.serviceLocator(),
+      addCategoryUsecase: DependencyHelper.instance.serviceLocator(),
+    ),
+  );
+
+  // USECASES
+  DependencyHelper.instance.serviceLocator.registerLazySingleton(
+    () => GetCategoriesUsecase(repository: DependencyHelper.instance.serviceLocator()),
+  );
+
+  DependencyHelper.instance.serviceLocator.registerLazySingleton(
+    () => AddCategoryUsecase(repository: DependencyHelper.instance.serviceLocator()),
+  );
+
+  // REPOSITORIES
+  DependencyHelper.instance.serviceLocator.registerLazySingleton<CategoryRepository>(
+    () => CategoryRepositoryImpl(remoteDataSource: DependencyHelper.instance.serviceLocator()),
+  );
+
+  // DATASOURCES
+  DependencyHelper.instance.serviceLocator.registerLazySingleton<CategoryRemoteDataSource>(
+    () => CategoryRemoteDataSourceImpl(),
+  );
+}

--- a/lib/features/category/domain/domain_imports.dart
+++ b/lib/features/category/domain/domain_imports.dart
@@ -1,0 +1,11 @@
+import 'package:dartz/dartz.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../../core/error/failures.dart';
+import '../../../core/standards/response_model.dart';
+import '../../../core/standards/use_case.dart';
+
+part '../domain/entities/category.dart';
+part '../domain/repositories/category_repository.dart';
+part '../domain/usecases/add_category_usecase.dart';
+part '../domain/usecases/get_categories_usecase.dart';

--- a/lib/features/category/domain/entities/category.dart
+++ b/lib/features/category/domain/entities/category.dart
@@ -1,0 +1,54 @@
+part of '../domain_imports.dart';
+
+class Category extends Equatable {
+  final int id;
+  final String name;
+  final String? parent;
+  final int active;
+  final String slug;
+  final String image;
+  final DateTime createdAt;
+
+  const Category({
+    required this.id,
+    required this.name,
+    required this.parent,
+    required this.active,
+    required this.slug,
+    required this.image,
+    required this.createdAt,
+  });
+
+  Category copyWith({
+    int? id,
+    String? name,
+    String? parent,
+    int? active,
+    String? slug,
+    String? image,
+    DateTime? createdAt,
+  }) {
+    return Category(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      parent: parent ?? this.parent,
+      active: active ?? this.active,
+      slug: slug ?? this.slug,
+      image: image ?? this.image,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  @override
+  List<Object?> get props {
+    return [
+      id,
+      name,
+      parent,
+      active,
+      slug,
+      image,
+      createdAt,
+    ];
+  }
+}

--- a/lib/features/category/domain/repositories/category_repository.dart
+++ b/lib/features/category/domain/repositories/category_repository.dart
@@ -1,0 +1,6 @@
+part of '../domain_imports.dart';
+
+abstract class CategoryRepository {
+  Future<Either<Failure, ApiResponse<List<Category>>>> getCategories();
+  Future<Either<Failure, ApiResponse<Category>>> addCategory(AddCategoryParams params);
+}

--- a/lib/features/category/domain/usecases/add_category_usecase.dart
+++ b/lib/features/category/domain/usecases/add_category_usecase.dart
@@ -1,0 +1,18 @@
+part of '../domain_imports.dart';
+
+class AddCategoryUsecase implements UseCase<ApiResponse<Category>, AddCategoryParams> {
+  final CategoryRepository repository;
+
+  const AddCategoryUsecase({required this.repository});
+
+  @override
+  Future<Either<Failure, ApiResponse<Category>>> call(AddCategoryParams params) async {
+    return repository.addCategory(params);
+  }
+}
+
+class AddCategoryParams {
+  Map<String, dynamic> toMap() {
+    return {};
+  }
+}

--- a/lib/features/category/domain/usecases/get_categories_usecase.dart
+++ b/lib/features/category/domain/usecases/get_categories_usecase.dart
@@ -1,0 +1,12 @@
+part of '../domain_imports.dart';
+
+class GetCategoriesUsecase implements UseCaseWithoutParam<ApiResponse<List<Category>>> {
+  final CategoryRepository repository;
+
+  const GetCategoriesUsecase({required this.repository});
+
+  @override
+  Future<Either<Failure, ApiResponse<List<Category>>>> call() async {
+    return await repository.getCategories();
+  }
+}

--- a/lib/features/category/presentation/cubit/category_cubit.dart
+++ b/lib/features/category/presentation/cubit/category_cubit.dart
@@ -1,0 +1,38 @@
+part of '../presentation_imports.dart';
+
+class CategoryCubit extends Cubit<CategoryState> {
+  CategoryCubit({
+    required this.getCategoriesUsecase,
+    required this.addCategoryUsecase,
+  }) : super(const CategoryState());
+
+  final GetCategoriesUsecase getCategoriesUsecase;
+  final AddCategoryUsecase addCategoryUsecase;
+
+  Future<void> getCategories() async {
+    emit(state.copyWith(categoriesStatus: UsecaseStatus.running));
+    final result = await getCategoriesUsecase();
+    result.fold(
+      (failure) {
+        emit(state.copyWith(categoriesStatus: UsecaseStatus.error, categoriesFailure: failure));
+      },
+      (categories) {
+        emit(state.copyWith(categoriesStatus: UsecaseStatus.completed, categories: categories.data));
+      },
+    );
+  }
+
+  Future<void> addCategory(AddCategoryParams params) async {
+    emit(state.copyWith(addCategoryStatus: UsecaseStatus.running));
+    final result = await addCategoryUsecase(params);
+    result.fold(
+      (failure) {
+        emit(state.copyWith(addCategoryStatus: UsecaseStatus.error, addCategoryFailure: failure));
+      },
+      (response) {
+        final oldCategories = List<Category>.from(state.categories);
+        emit(state.copyWith(addCategoryStatus: UsecaseStatus.completed, categories: oldCategories..insert(0, response.data!)));
+      },
+    );
+  }
+}

--- a/lib/features/category/presentation/cubit/category_state.dart
+++ b/lib/features/category/presentation/cubit/category_state.dart
@@ -1,0 +1,48 @@
+part of '../presentation_imports.dart';
+
+class CategoryState extends Equatable {
+  const CategoryState({
+    this.categoriesStatus = UsecaseStatus.idle,
+    this.categoriesFailure,
+    this.categories = const [],
+    this.addCategoryStatus = UsecaseStatus.idle,
+    this.addCategoryFailure,
+  });
+
+  final UsecaseStatus categoriesStatus;
+  final Failure? categoriesFailure;
+  final List<Category> categories;
+
+  final UsecaseStatus addCategoryStatus;
+  final Failure? addCategoryFailure;
+
+  CategoryState copyWith({
+    UsecaseStatus? categoriesStatus,
+    Failure? categoriesFailure,
+    List<Category>? categories,
+    UsecaseStatus? addCategoryStatus,
+    Failure? addCategoryFailure,
+  }) {
+    return CategoryState(
+      categoriesStatus: categoriesStatus ?? this.categoriesStatus,
+      categoriesFailure: categoriesFailure ?? this.categoriesFailure,
+      categories: categories ?? this.categories,
+      addCategoryStatus: addCategoryStatus ?? this.addCategoryStatus,
+      addCategoryFailure: addCategoryFailure ?? this.addCategoryFailure,
+    );
+  }
+
+  @override
+  String toString() {
+    return 'CategoryState(categoriesStatus: $categoriesStatus, categoriesFailure: $categoriesFailure, categories: $categories, addCategoryStatus: $addCategoryStatus, addCategoryFailure: $addCategoryFailure)';
+  }
+
+  @override
+  List<Object?> get props => [
+        categoriesStatus,
+        categoriesFailure,
+        categories,
+        addCategoryStatus,
+        addCategoryFailure,
+      ];
+}

--- a/lib/features/category/presentation/pages/categories_page.dart
+++ b/lib/features/category/presentation/pages/categories_page.dart
@@ -1,0 +1,39 @@
+part of '../presentation_imports.dart';
+
+class CategoriesPage extends StatelessWidget {
+  const CategoriesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => DependencyHelper.instance.get<CategoryCubit>()..getCategories(),
+      child: const CategoriesPageBody(),
+    );
+  }
+}
+
+class CategoriesPageBody extends StatelessWidget {
+  const CategoriesPageBody({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const MainAppBar(),
+      body: const Column(
+        children: [
+          CategoriesHorizontalList(),
+        ],
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          final cubit = context.read<CategoryCubit>();
+          await context.showSheet<Category>(child: AddCategorySheet(categoryCubit: cubit));
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/features/category/presentation/presentation_imports.dart
+++ b/lib/features/category/presentation/presentation_imports.dart
@@ -1,0 +1,23 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+import '../../../core/error/failures.dart';
+import '../../../core/extensions/context.dart';
+import '../../../core/extensions/sheet.dart';
+import '../../../core/extensions/spaced_column.dart';
+import '../../../core/helpers/dependency_helper.dart';
+import '../../../core/navigation/navigator.dart';
+import '../../../core/shared_widgets/core_widgets/image_widget.dart';
+import '../../../core/shared_widgets/core_widgets/main_app_bar.dart';
+import '../../../core/standards/usecase_status.dart';
+import '../../sub_category/presentation/presentation_imports.dart';
+import '../domain/domain_imports.dart';
+
+part '../presentation/cubit/category_cubit.dart';
+part '../presentation/cubit/category_state.dart';
+part '../presentation/widgets/add_category_sheet.dart';
+part '../presentation/widgets/categories_horizontal_list.dart';
+part '../presentation/widgets/category_card.dart';
+part 'pages/categories_page.dart';

--- a/lib/features/category/presentation/widgets/add_category_sheet.dart
+++ b/lib/features/category/presentation/widgets/add_category_sheet.dart
@@ -1,0 +1,63 @@
+part of '../presentation_imports.dart';
+
+class AddCategorySheet extends StatefulWidget {
+  const AddCategorySheet({super.key, required this.categoryCubit});
+
+  final CategoryCubit categoryCubit;
+
+  @override
+  State<AddCategorySheet> createState() => _AddCategorySheetState();
+}
+
+class _AddCategorySheetState extends State<AddCategorySheet> {
+  final _formKey = GlobalKey<FormState>();
+  final _titleController = TextEditingController();
+  final _bodyController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider.value(
+      value: widget.categoryCubit,
+      child: BlocConsumer<CategoryCubit, CategoryState>(
+        listener: (context, state) {
+          if (state.addCategoryStatus == UsecaseStatus.completed) {
+            AppNavigator.pop();
+          }
+        },
+        builder: (context, state) {
+          return Padding(
+            padding: REdgeInsets.all(16.0).copyWith(
+              bottom: context.bottomBarHeight + 16.h,
+            ),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  TextField(
+                    controller: _titleController,
+                    decoration: const InputDecoration(labelText: 'Title'),
+                  ),
+                  TextField(
+                    controller: _bodyController,
+                    decoration: const InputDecoration(labelText: 'Body'),
+                  ),
+                  ElevatedButton(
+                    onPressed: () {
+                      if (!_formKey.currentState!.validate()) return;
+                      if (state.addCategoryStatus == UsecaseStatus.running) return;
+
+                      widget.categoryCubit.addCategory(AddCategoryParams());
+                    },
+                    child: state.addCategoryStatus == UsecaseStatus.running ? const CircularProgressIndicator.adaptive() : const Text('Add'),
+                  ),
+                ],
+              ).withSpacing(spacing: 16.h),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/category/presentation/widgets/categories_horizontal_list.dart
+++ b/lib/features/category/presentation/widgets/categories_horizontal_list.dart
@@ -1,0 +1,36 @@
+part of '../presentation_imports.dart';
+
+class CategoriesHorizontalList extends StatelessWidget {
+  const CategoriesHorizontalList({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: EdgeInsets.symmetric(horizontal: 16.w),
+          child: Text("Categories", style: context.appTextStyle.elevatedButtonTextStyle),
+        ),
+        BlocSelector<CategoryCubit, CategoryState, ({UsecaseStatus status, Failure? failure, List<Category> categories})>(
+          selector: (state) => (status: state.categoriesStatus, failure: state.categoriesFailure, categories: state.categories),
+          builder: (context, state) {
+            return SizedBox(
+              height: 150.h,
+              child: ListView.separated(
+                padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 16.h),
+                scrollDirection: Axis.horizontal,
+                itemCount: state.categories.length,
+                separatorBuilder: (context, index) => SizedBox(height: 16.h),
+                itemBuilder: (context, index) {
+                  final category = state.categories[index];
+                  return CategoryCard(category);
+                },
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/category/presentation/widgets/category_card.dart
+++ b/lib/features/category/presentation/widgets/category_card.dart
@@ -1,0 +1,27 @@
+part of '../presentation_imports.dart';
+
+class CategoryCard extends StatelessWidget {
+  const CategoryCard(this.category, {super.key});
+
+  final Category category;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: () {
+        AppNavigator.to(SubCategoriesPage(categoryId: category.id));
+      },
+      child: Column(
+        children: [
+          ImageWidget(
+            imageUrl: category.image,
+            height: 70.r,
+            width: 70.r,
+            shape: BoxShape.circle,
+          ),
+          Text(category.name, style: context.appTextStyle.elevatedButtonTextStyle),
+        ],
+      ).withSpacing(spacing: 8.h),
+    );
+  }
+}

--- a/lib/features/layout/presentation/pages/layout_page.dart
+++ b/lib/features/layout/presentation/pages/layout_page.dart
@@ -13,6 +13,9 @@ class LayoutPage extends StatelessWidget {
         BlocProvider(
           create: (context) => DependencyHelper.instance.get<AdCubit>()..getAds(),
         ),
+        BlocProvider(
+          create: (context) => DependencyHelper.instance.get<CategoryCubit>()..getCategories(),
+        ),
       ],
       child: const LayoutPageBody(),
     );

--- a/lib/features/layout/presentation/presentation_imports.dart
+++ b/lib/features/layout/presentation/presentation_imports.dart
@@ -2,6 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:medina_stores/features/ad/presentation/presentation_imports.dart';
+import 'package:medina_stores/features/category/presentation/presentation_imports.dart';
 import 'package:medina_stores/features/main/presentation/presentation_imports.dart';
 import 'package:medina_stores/features/profile/presentation/presentation_imports.dart';
 

--- a/lib/features/main/presentation/pages/main_tab_page.dart
+++ b/lib/features/main/presentation/pages/main_tab_page.dart
@@ -24,6 +24,7 @@ class MainTabPageBody extends StatelessWidget {
         child: const Column(
           children: [
             AdsScrollingWidget(),
+            CategoriesHorizontalList(),
           ],
         ).withSpacing(spacing: 16.h),
       ),

--- a/lib/features/main/presentation/presentation_imports.dart
+++ b/lib/features/main/presentation/presentation_imports.dart
@@ -9,6 +9,7 @@ import 'package:medina_stores/features/ad/presentation/presentation_imports.dart
 
 import '../../../core/helpers/dependency_helper.dart';
 import '../../../core/shared_widgets/core_widgets/main_app_bar.dart';
+import '../../category/presentation/presentation_imports.dart';
 
 part '../presentation/cubit/main_cubit.dart';
 part '../presentation/cubit/main_state.dart';

--- a/lib/features/sub_category/data/data_imports.dart
+++ b/lib/features/sub_category/data/data_imports.dart
@@ -1,0 +1,18 @@
+import 'dart:convert';
+
+import 'package:dartz/dartz.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:medina_stores/core/standards/drop_down_item.dart';
+
+import '../../../../core/helpers/dependency_helper.dart';
+import '../../../../core/networking/api_request.dart';
+import '../../../../core/networking/api_service.dart';
+import '../../../core/error/failures.dart';
+import '../../../core/extensions/error_handler_extension.dart';
+import '../../../core/networking/api_constants.dart';
+import '../../../core/standards/response_model.dart';
+import '../domain/domain_imports.dart';
+
+part '../data/datasources/sub_category_remote_data_source.dart';
+part '../data/models/sub_category_model.dart';
+part '../data/repositories/sub_category_repository_impl.dart';

--- a/lib/features/sub_category/data/datasources/sub_category_remote_data_source.dart
+++ b/lib/features/sub_category/data/datasources/sub_category_remote_data_source.dart
@@ -1,0 +1,41 @@
+part of '../data_imports.dart';
+
+abstract class SubCategoryRemoteDataSource {
+  Future<ApiResponse<List<SubCategoryModel>>> getSubCategories(int categoryId);
+  Future<ApiResponse<SubCategoryModel>> addSubCategory(AddSubCategoryParams params);
+}
+
+class SubCategoryRemoteDataSourceImpl implements SubCategoryRemoteDataSource {
+  @override
+  Future<ApiResponse<List<SubCategoryModel>>> getSubCategories(int categoryId) async {
+    final request = ApiRequest(
+      method: RequestMethod.get,
+      path: '${ApiConstants.endPoints.CATEGORIES}/$categoryId/${ApiConstants.endPoints.SUB_CATEGORIES}',
+    );
+
+    return await DependencyHelper.instance.get<ApiService>().callApi<List<SubCategoryModel>>(
+          request,
+          mapper: (json) => ApiResponse.fromMapSuccess(
+            json,
+            mapper: (data) => List<SubCategoryModel>.from(data['data'].map((x) => SubCategoryModel.fromMap(x))),
+          ),
+        );
+  }
+
+  @override
+  Future<ApiResponse<SubCategoryModel>> addSubCategory(AddSubCategoryParams params) async {
+    final request = ApiRequest(
+      method: RequestMethod.post,
+      path: "/dashboard/branches",
+      body: params.toMap(),
+    );
+
+    return await DependencyHelper.instance.get<ApiService>().callApi<SubCategoryModel>(
+          request,
+          mapper: (json) => ApiResponse.fromMapSuccess(
+            json,
+            mapper: (data) => SubCategoryModel.fromMap(data),
+          ),
+        );
+  }
+}

--- a/lib/features/sub_category/data/models/sub_category_model.dart
+++ b/lib/features/sub_category/data/models/sub_category_model.dart
@@ -1,0 +1,41 @@
+part of '../data_imports.dart';
+
+class SubCategoryModel extends SubCategory {
+  const SubCategoryModel({
+    required super.id,
+    required super.name,
+    required super.parent,
+    required super.active,
+    required super.slug,
+    required super.image,
+    required super.createdAt,
+  });
+
+  factory SubCategoryModel.fromMap(Map<String, dynamic> map) {
+    return SubCategoryModel(
+      id: map['id'],
+      name: map['name'],
+      parent: DropdownItemModel.fromMap(map['parent']),
+      active: map['active'],
+      slug: map['slug'],
+      image: map['image'],
+      createdAt: DateFormat('yyyy MMM dd hh:mm:ss').parse(map['created_at']),
+    );
+  }
+
+  factory SubCategoryModel.fromJson(String source) => SubCategoryModel.fromMap(json.decode(source));
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'name': name,
+      'parent': (parent as DropdownItemModel).toMap(),
+      'active': active,
+      'slug': slug,
+      'image': image,
+      'created_at': DateFormat('yyyy MMM dd hh:mm:ss').format(createdAt),
+    };
+  }
+
+  String toJson() => json.encode(toMap());
+}

--- a/lib/features/sub_category/data/repositories/sub_category_repository_impl.dart
+++ b/lib/features/sub_category/data/repositories/sub_category_repository_impl.dart
@@ -1,0 +1,17 @@
+part of '../data_imports.dart';
+
+class SubCategoryRepositoryImpl implements SubCategoryRepository {
+  final SubCategoryRemoteDataSource remoteDataSource;
+
+  const SubCategoryRepositoryImpl({required this.remoteDataSource});
+
+  @override
+  Future<Either<Failure, ApiResponse<List<SubCategory>>>> getSubCategories(int categoryId) async {
+    return await remoteDataSource.getSubCategories(categoryId).handleCallbackWithFailure;
+  }
+
+  @override
+  Future<Either<Failure, ApiResponse<SubCategory>>> addSubCategory(AddSubCategoryParams params) async {
+    return await remoteDataSource.addSubCategory(params).handleCallbackWithFailure;
+  }
+}

--- a/lib/features/sub_category/di/setup_sub_category_dependencies.dart
+++ b/lib/features/sub_category/di/setup_sub_category_dependencies.dart
@@ -1,0 +1,33 @@
+import '../../../core/helpers/dependency_helper.dart';
+import '../data/data_imports.dart';
+import '../domain/domain_imports.dart';
+import '../presentation/presentation_imports.dart';
+
+void setUpSubCategoryDependencies() async {
+  // CUBIT
+  DependencyHelper.instance.serviceLocator.registerFactory(
+    () => SubCategoryCubit(
+      getSubCategoriesUsecase: DependencyHelper.instance.serviceLocator(),
+      addSubCategoryUsecase: DependencyHelper.instance.serviceLocator(),
+    ),
+  );
+
+  // USECASES
+  DependencyHelper.instance.serviceLocator.registerLazySingleton(
+    () => GetSubCategoriesUsecase(repository: DependencyHelper.instance.serviceLocator()),
+  );
+
+  DependencyHelper.instance.serviceLocator.registerLazySingleton(
+    () => AddSubCategoryUsecase(repository: DependencyHelper.instance.serviceLocator()),
+  );
+
+  // REPOSITORIES
+  DependencyHelper.instance.serviceLocator.registerLazySingleton<SubCategoryRepository>(
+    () => SubCategoryRepositoryImpl(remoteDataSource: DependencyHelper.instance.serviceLocator()),
+  );
+
+  // DATASOURCES
+  DependencyHelper.instance.serviceLocator.registerLazySingleton<SubCategoryRemoteDataSource>(
+    () => SubCategoryRemoteDataSourceImpl(),
+  );
+}

--- a/lib/features/sub_category/domain/domain_imports.dart
+++ b/lib/features/sub_category/domain/domain_imports.dart
@@ -1,0 +1,12 @@
+import 'package:dartz/dartz.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../../core/error/failures.dart';
+import '../../../core/standards/drop_down_item.dart';
+import '../../../core/standards/response_model.dart';
+import '../../../core/standards/use_case.dart';
+
+part '../domain/entities/sub_category.dart';
+part '../domain/repositories/sub_category_repository.dart';
+part '../domain/usecases/add_sub_category_usecase.dart';
+part '../domain/usecases/get_sub_categories_usecase.dart';

--- a/lib/features/sub_category/domain/entities/sub_category.dart
+++ b/lib/features/sub_category/domain/entities/sub_category.dart
@@ -1,0 +1,46 @@
+part of '../domain_imports.dart';
+
+class SubCategory extends Equatable {
+  final int id;
+  final String name;
+  final DropdownItem parent;
+  final int active;
+  final String slug;
+  final String image;
+  final DateTime createdAt;
+
+  const SubCategory({
+    required this.id,
+    required this.name,
+    required this.parent,
+    required this.active,
+    required this.slug,
+    required this.image,
+    required this.createdAt,
+  });
+
+  SubCategory copyWith({
+    int? id,
+    String? name,
+    DropdownItem? parent,
+    int? active,
+    String? slug,
+    String? image,
+    DateTime? createdAt,
+  }) {
+    return SubCategory(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      parent: parent ?? this.parent,
+      active: active ?? this.active,
+      slug: slug ?? this.slug,
+      image: image ?? this.image,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  @override
+  List<Object?> get props {
+    return [id, name, parent, active, slug, image, createdAt];
+  }
+}

--- a/lib/features/sub_category/domain/repositories/sub_category_repository.dart
+++ b/lib/features/sub_category/domain/repositories/sub_category_repository.dart
@@ -1,0 +1,6 @@
+part of '../domain_imports.dart';
+
+abstract class SubCategoryRepository {
+  Future<Either<Failure, ApiResponse<List<SubCategory>>>> getSubCategories(int categoryId);
+  Future<Either<Failure, ApiResponse<SubCategory>>> addSubCategory(AddSubCategoryParams params);
+}

--- a/lib/features/sub_category/domain/usecases/add_sub_category_usecase.dart
+++ b/lib/features/sub_category/domain/usecases/add_sub_category_usecase.dart
@@ -1,0 +1,18 @@
+part of '../domain_imports.dart';
+
+class AddSubCategoryUsecase implements UseCase<ApiResponse<SubCategory>, AddSubCategoryParams> {
+  final SubCategoryRepository repository;
+
+  const AddSubCategoryUsecase({required this.repository});
+
+  @override
+  Future<Either<Failure, ApiResponse<SubCategory>>> call(AddSubCategoryParams params) async {
+    return repository.addSubCategory(params);
+  }
+}
+
+class AddSubCategoryParams {
+  Map<String, dynamic> toMap() {
+    return {};
+  }
+}

--- a/lib/features/sub_category/domain/usecases/get_sub_categories_usecase.dart
+++ b/lib/features/sub_category/domain/usecases/get_sub_categories_usecase.dart
@@ -1,0 +1,12 @@
+part of '../domain_imports.dart';
+
+class GetSubCategoriesUsecase implements UseCase<ApiResponse<List<SubCategory>>, int> {
+  final SubCategoryRepository repository;
+
+  const GetSubCategoriesUsecase({required this.repository});
+
+  @override
+  Future<Either<Failure, ApiResponse<List<SubCategory>>>> call(int param) async {
+    return await repository.getSubCategories(param);
+  }
+}

--- a/lib/features/sub_category/presentation/cubit/sub_category_cubit.dart
+++ b/lib/features/sub_category/presentation/cubit/sub_category_cubit.dart
@@ -1,0 +1,38 @@
+part of '../presentation_imports.dart';
+
+class SubCategoryCubit extends Cubit<SubCategoryState> {
+  SubCategoryCubit({
+    required this.getSubCategoriesUsecase,
+    required this.addSubCategoryUsecase,
+  }) : super(const SubCategoryState());
+
+  final GetSubCategoriesUsecase getSubCategoriesUsecase;
+  final AddSubCategoryUsecase addSubCategoryUsecase;
+
+  Future<void> getSubCategories(int categoryId) async {
+    emit(state.copyWith(subCategoriesStatus: UsecaseStatus.running));
+    final result = await getSubCategoriesUsecase(categoryId);
+    result.fold(
+      (failure) {
+        emit(state.copyWith(subCategoriesStatus: UsecaseStatus.error, subCategoriesFailure: failure));
+      },
+      (subCategories) {
+        emit(state.copyWith(subCategoriesStatus: UsecaseStatus.completed, subCategories: subCategories.data));
+      },
+    );
+  }
+
+  Future<void> addSubCategory(AddSubCategoryParams params) async {
+    emit(state.copyWith(addSubCategoryStatus: UsecaseStatus.running));
+    final result = await addSubCategoryUsecase(params);
+    result.fold(
+      (failure) {
+        emit(state.copyWith(addSubCategoryStatus: UsecaseStatus.error, addSubCategoryFailure: failure));
+      },
+      (response) {
+        final oldSubCategories = List<SubCategory>.from(state.subCategories);
+        emit(state.copyWith(addSubCategoryStatus: UsecaseStatus.completed, subCategories: oldSubCategories..insert(0, response.data!)));
+      },
+    );
+  }
+}

--- a/lib/features/sub_category/presentation/cubit/sub_category_state.dart
+++ b/lib/features/sub_category/presentation/cubit/sub_category_state.dart
@@ -1,0 +1,48 @@
+part of '../presentation_imports.dart';
+
+class SubCategoryState extends Equatable {
+  const SubCategoryState({
+    this.subCategoriesStatus = UsecaseStatus.idle,
+    this.subCategoriesFailure,
+    this.subCategories = const [],
+    this.addSubCategoryStatus = UsecaseStatus.idle,
+    this.addSubCategoryFailure,
+  });
+
+  final UsecaseStatus subCategoriesStatus;
+  final Failure? subCategoriesFailure;
+  final List<SubCategory> subCategories;
+
+  final UsecaseStatus addSubCategoryStatus;
+  final Failure? addSubCategoryFailure;
+
+  SubCategoryState copyWith({
+    UsecaseStatus? subCategoriesStatus,
+    Failure? subCategoriesFailure,
+    List<SubCategory>? subCategories,
+    UsecaseStatus? addSubCategoryStatus,
+    Failure? addSubCategoryFailure,
+  }) {
+    return SubCategoryState(
+      subCategoriesStatus: subCategoriesStatus ?? this.subCategoriesStatus,
+      subCategoriesFailure: subCategoriesFailure ?? this.subCategoriesFailure,
+      subCategories: subCategories ?? this.subCategories,
+      addSubCategoryStatus: addSubCategoryStatus ?? this.addSubCategoryStatus,
+      addSubCategoryFailure: addSubCategoryFailure ?? this.addSubCategoryFailure,
+    );
+  }
+
+  @override
+  String toString() {
+    return 'SubCategoryState(subCategoriesStatus: $subCategoriesStatus, subCategoriesFailure: $subCategoriesFailure, subCategories: $subCategories, addSubCategoryStatus: $addSubCategoryStatus, addSubCategoryFailure: $addSubCategoryFailure)';
+  }
+
+  @override
+  List<Object?> get props => [
+        subCategoriesStatus,
+        subCategoriesFailure,
+        subCategories,
+        addSubCategoryStatus,
+        addSubCategoryFailure,
+      ];
+}

--- a/lib/features/sub_category/presentation/pages/sub_categories_page.dart
+++ b/lib/features/sub_category/presentation/pages/sub_categories_page.dart
@@ -1,0 +1,41 @@
+part of '../presentation_imports.dart';
+
+class SubCategoriesPage extends StatelessWidget {
+  const SubCategoriesPage({super.key, required this.categoryId});
+
+  final int categoryId;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => DependencyHelper.instance.get<SubCategoryCubit>()..getSubCategories(categoryId),
+      child: const SubCategoriesPageBody(),
+    );
+  }
+}
+
+class SubCategoriesPageBody extends StatelessWidget {
+  const SubCategoriesPageBody({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const MainAppBar(title: Text('Sub Categories')),
+      body: const Column(
+        children: [
+          SubCategoriesHorizontalList(),
+        ],
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          final cubit = context.read<SubCategoryCubit>();
+          await context.showSheet<SubCategory>(child: AddSubCategorySheet(subCategoryCubit: cubit));
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/features/sub_category/presentation/presentation_imports.dart
+++ b/lib/features/sub_category/presentation/presentation_imports.dart
@@ -1,0 +1,22 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:medina_stores/core/extensions/sheet.dart';
+import 'package:medina_stores/core/shared_widgets/core_widgets/image_widget.dart';
+
+import '../../../core/error/failures.dart';
+import '../../../core/extensions/context.dart';
+import '../../../core/extensions/spaced_column.dart';
+import '../../../core/helpers/dependency_helper.dart';
+import '../../../core/navigation/navigator.dart';
+import '../../../core/shared_widgets/core_widgets/main_app_bar.dart';
+import '../../../core/standards/usecase_status.dart';
+import '../domain/domain_imports.dart';
+
+part '../presentation/cubit/sub_category_cubit.dart';
+part '../presentation/cubit/sub_category_state.dart';
+part '../presentation/pages/sub_categories_page.dart';
+part '../presentation/widgets/add_sub_category_sheet.dart';
+part '../presentation/widgets/sub_categories_horizontal_list.dart';
+part '../presentation/widgets/sub_category_card.dart';

--- a/lib/features/sub_category/presentation/widgets/add_sub_category_sheet.dart
+++ b/lib/features/sub_category/presentation/widgets/add_sub_category_sheet.dart
@@ -1,0 +1,63 @@
+part of '../presentation_imports.dart';
+
+class AddSubCategorySheet extends StatefulWidget {
+  const AddSubCategorySheet({super.key, required this.subCategoryCubit});
+
+  final SubCategoryCubit subCategoryCubit;
+
+  @override
+  State<AddSubCategorySheet> createState() => _AddSubCategorySheetState();
+}
+
+class _AddSubCategorySheetState extends State<AddSubCategorySheet> {
+  final _formKey = GlobalKey<FormState>();
+  final _titleController = TextEditingController();
+  final _bodyController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider.value(
+      value: widget.subCategoryCubit,
+      child: BlocConsumer<SubCategoryCubit, SubCategoryState>(
+        listener: (context, state) {
+          if (state.addSubCategoryStatus == UsecaseStatus.completed) {
+            AppNavigator.pop();
+          }
+        },
+        builder: (context, state) {
+          return Padding(
+            padding: REdgeInsets.all(16.0).copyWith(
+              bottom: context.bottomBarHeight + 16.h,
+            ),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  TextField(
+                    controller: _titleController,
+                    decoration: const InputDecoration(labelText: 'Title'),
+                  ),
+                  TextField(
+                    controller: _bodyController,
+                    decoration: const InputDecoration(labelText: 'Body'),
+                  ),
+                  ElevatedButton(
+                    onPressed: () {
+                      if (!_formKey.currentState!.validate()) return;
+                      if (state.addSubCategoryStatus == UsecaseStatus.running) return;
+
+                      widget.subCategoryCubit.addSubCategory(AddSubCategoryParams());
+                    },
+                    child: state.addSubCategoryStatus == UsecaseStatus.running ? const CircularProgressIndicator.adaptive() : const Text('Add'),
+                  ),
+                ],
+              ).withSpacing(spacing: 16.h),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/sub_category/presentation/widgets/sub_categories_horizontal_list.dart
+++ b/lib/features/sub_category/presentation/widgets/sub_categories_horizontal_list.dart
@@ -1,0 +1,27 @@
+part of '../presentation_imports.dart';
+
+class SubCategoriesHorizontalList extends StatelessWidget {
+  const SubCategoriesHorizontalList({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocSelector<SubCategoryCubit, SubCategoryState, ({UsecaseStatus status, Failure? failure, List<SubCategory> subCategories})>(
+      selector: (state) => (status: state.subCategoriesStatus, failure: state.subCategoriesFailure, subCategories: state.subCategories),
+      builder: (context, state) {
+        return SizedBox(
+          height: 150.h,
+          child: ListView.separated(
+            scrollDirection: Axis.horizontal,
+            padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 16.h),
+            itemCount: state.subCategories.length,
+            separatorBuilder: (context, index) => SizedBox(width: 16.w),
+            itemBuilder: (context, index) {
+              final subCategory = state.subCategories[index];
+              return SubCategoryCard(subCategory);
+            },
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/sub_category/presentation/widgets/sub_category_card.dart
+++ b/lib/features/sub_category/presentation/widgets/sub_category_card.dart
@@ -1,0 +1,22 @@
+part of '../presentation_imports.dart';
+
+class SubCategoryCard extends StatelessWidget {
+  const SubCategoryCard(this.subCategory, {super.key});
+
+  final SubCategory subCategory;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        ImageWidget(
+          imageUrl: subCategory.image,
+          height: 70.r,
+          width: 70.r,
+          shape: BoxShape.circle,
+        ),
+        Text(subCategory.name, style: context.appTextStyle.elevatedButtonTextStyle),
+      ],
+    ).withSpacing(spacing: 8.h);
+  }
+}


### PR DESCRIPTION
This pull request refactors the category and subcategory repositories and usecases. It adds the necessary code for retrieving categories and subcategories from the remote data source and handling the API responses. It also includes the necessary usecases for adding categories and subcategories. Additionally, it updates the presentation layer by adding new widgets for displaying categories and subcategories.