### PR TITLE
Refactor Android Fastlane Workflow

### DIFF
--- a/android/Gemfile.lock
+++ b/android/Gemfile.lock
@@ -113,6 +113,8 @@ GEM
     fastlane-plugin-firebase_app_distribution (0.9.1)
       google-apis-firebaseappdistribution_v1 (~> 0.3.0)
       google-apis-firebaseappdistribution_v1alpha (~> 0.2.0)
+    fastlane-plugin-increment_version_code (0.4.3)
+    fastlane-plugin-versioning (0.6.0)
     gh_inspector (1.1.3)
     google-apis-androidpublisher_v3 (0.54.0)
       google-apis-core (>= 0.11.0, < 2.a)
@@ -225,6 +227,8 @@ PLATFORMS
 DEPENDENCIES
   fastlane (= 2.219.0)
   fastlane-plugin-firebase_app_distribution
+  fastlane-plugin-increment_version_code
+  fastlane-plugin-versioning
 
 BUNDLED WITH
-   2.4.22
+   2.5.17

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -18,20 +18,32 @@ default_platform(:android)
 ENV["ANDROID_APP_ID"] = "1:978985818662:android:449f454e10a1d4401ae4e7"
 
 platform :android do
-  desc "Increment build number"
-  lane :increment_version do
+  lane :increment_build_and_version_number do
+    gradle_file = "./app/build.gradle"
     latest_release = firebase_app_distribution_get_latest_release(
       app: ENV["ANDROID_APP_ID"],
       firebase_cli_token: ENV["FIREBASE_CLI_TOKEN"],
     )
-    increment_build_number({ build_number: latest_release[:buildVersion].to_i + 1 })
+    current_version = latest_release[:displayVersion]
+    current_build = latest_release[:buildVersion]
+
+    # Split the version number into its components
+    version_parts = current_version.split(".")
+    
+    # Increment the minor version and reset the patch version
+    version_parts[1] = (version_parts[1].to_i + 1).to_s
+    version_parts[2] = "0"
+    
+    new_version = version_parts.join(".")
+
+    # if you want to increment version name add `--build-name=#{new_version}` to the command
+    sh "flutter build apk --release --no-tree-shake-icons --build-number=#{current_build.to_i + 1}"
   end
 
   desc "Lane to build and distribute the android app"
   lane :firebase_distribution do
     sh "flutter clean"
-    increment_version
-    sh "flutter build apk --release --no-tree-shake-icons"
+    increment_build_and_version_number
     firebase_app_distribution(
       app: ENV["ANDROID_APP_ID"],
       firebase_cli_token: ENV["FIREBASE_CLI_TOKEN"],

--- a/android/fastlane/Pluginfile
+++ b/android/fastlane/Pluginfile
@@ -3,3 +3,5 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-firebase_app_distribution'
+gem 'fastlane-plugin-versioning'
+gem 'fastlane-plugin-increment_version_code'

--- a/android/fastlane/README.md
+++ b/android/fastlane/README.md
@@ -15,6 +15,14 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 ## Android
 
+### android increment_build_and_version_number
+
+```sh
+[bundle exec] fastlane android increment_build_and_version_number
+```
+
+
+
 ### android firebase_distribution
 
 ```sh

--- a/android/fastlane/report.xml
+++ b/android/fastlane/report.xml
@@ -5,22 +5,27 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000203">
+      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000212">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="1: flutter clean" time="5.007344">
+      <testcase classname="fastlane.lanes" name="1: flutter clean" time="4.653927">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="2: flutter build apk --release --no-tree-shake-icons" time="60.268128">
+      <testcase classname="fastlane.lanes" name="2: Switch to android increment_build_and_version_number lane" time="0.000267">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="3: firebase_app_distribution" time="117.344218">
+      <testcase classname="fastlane.lanes" name="3: firebase_app_distribution_get_latest_release" time="1.162502">
+        
+      </testcase>
+    
+      
+      <testcase classname="fastlane.lanes" name="4: flutter build apk --release --no-tree-shake-icons --build-number=2" time="12.49471">
         
       </testcase>
     


### PR DESCRIPTION
This pull request refactors the Android Fastlane workflow. It updates the Fastlane version to 2.219.0 and adds the following plugins: fastlane-plugin-firebase_app_distribution, fastlane-plugin-increment_version_code, and fastlane-plugin-versioning. The `increment_build_and_version_number` lane has been added to increment the build number and version number of the Android app. The `firebase_distribution` lane now calls the `increment_build_and_version_number` lane before building and distributing the Android app.