### PR TITLE
Refactor Android Fastlane Workflow

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -37,7 +37,7 @@ platform :android do
     new_version = version_parts.join(".")
 
     # if you want to increment version name add `--build-name=#{new_version}` to the command
-    sh "flutter build apk --release --no-tree-shake-icons --build-number=#{current_build.to_i + 1}"
+    sh "flutter build apk --release --no-tree-shake-icons --build-name=#{current_version} --build-number=#{current_build.to_i + 1}"
   end
 
   desc "Lane to build and distribute the android app"


### PR DESCRIPTION
This pull request refactors the Android Fastlane Workflow. It updates the Fastlane version to 2.5.17 and adds two new plugins: fastlane-plugin-increment_version_code and fastlane-plugin-versioning. The changes include modifying the increment_version lane to increment both the build number and version number, splitting the version number into its components, incrementing the minor version and resetting the patch version, and building the APK with the updated version and build numbers. The firebase_distribution lane now calls the increment_build_and_version_number lane instead of the increment_version lane.