### PR TITLE
Improve performance of CategoriesLisViewWidget

### DIFF
--- a/lib/features/category/presentation/widgets/categories_lisview_widget.dart
+++ b/lib/features/category/presentation/widgets/categories_lisview_widget.dart
@@ -9,13 +9,10 @@ class CategoriesLisViewWidget extends StatelessWidget {
       selector: (state) => (status: state.categoriesStatus, failure: state.categoriesFailure, categories: state.categories),
       builder: (context, cState) {
         final isLoading = cState.status == UsecaseStatus.running;
-        if (isLoading) {
-          return CategoryWithSubsCard.skeleton();
-        }
         if (cState.failure != null) {
           return Center(child: Text("Failed to load sub categories ${cState.failure!.response.message}"));
         }
-        if (cState.categories.isEmpty) {
+        if (cState.categories.isEmpty && !isLoading) {
           return Center(child: Text(LocaleKeys.empty_sub_categories.tr()));
         }
 
@@ -23,11 +20,12 @@ class CategoriesLisViewWidget extends StatelessWidget {
           shrinkWrap: true,
           physics: const NeverScrollableScrollPhysics(),
           itemBuilder: (context, index) {
+            if (isLoading) return CategoryWithSubsCard.skeleton();
             final category = cState.categories[index];
             return CategoryWithSubsCard(category);
           },
           separatorBuilder: (context, index) => SizedBox(height: 16.h),
-          itemCount: cState.categories.length,
+          itemCount: isLoading ? 4 : cState.categories.length,
         );
       },
     );

--- a/lib/features/category/presentation/widgets/category_with_subs_card.dart
+++ b/lib/features/category/presentation/widgets/category_with_subs_card.dart
@@ -31,19 +31,18 @@ class CategoryWithSubsCard extends StatelessWidget {
             padding: EdgeInsets.symmetric(horizontal: 16.w),
             child: Text(LocaleKeys.empty_sub_categories.tr()),
           ),
-        if (category.children.isNotEmpty)
-          DynamicHeightGridView(
-            padding: EdgeInsets.symmetric(horizontal: 16.w),
-            crossAxisCount: 4,
-            itemCount: _isSkeleton ? 4 : category.children.length,
-            shrinkWrap: true,
-            physics: const NeverScrollableScrollPhysics(),
-            builder: (context, index) {
-              if (_isSkeleton) return SubCategoryCard.skeleton();
-              final subCategory = category.children[index];
-              return SubCategoryCard(subCategory);
-            },
-          ),
+        DynamicHeightGridView(
+          padding: EdgeInsets.symmetric(horizontal: 16.w),
+          crossAxisCount: 4,
+          itemCount: _isSkeleton ? 4 : category.children.length,
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          builder: (context, index) {
+            if (_isSkeleton) return SubCategoryCard.skeleton();
+            final subCategory = category.children[index];
+            return SubCategoryCard(subCategory);
+          },
+        ),
       ],
     );
   }


### PR DESCRIPTION
This pull request improves the performance of the CategoriesLisViewWidget by optimizing the rendering of subcategories. Previously, when loading subcategories, a loading indicator was displayed for each category, resulting in unnecessary rendering. This PR updates the logic to only display the loading indicator once, improving the overall performance of the widget.