### PR TITLE
Update product details status and data in ProductCubit

### DIFF
--- a/lib/features/product/presentation/cubit/product_cubit.dart
+++ b/lib/features/product/presentation/cubit/product_cubit.dart
@@ -125,7 +125,10 @@ class ProductCubit extends Cubit<ProductState> {
   }
 
   Future<void> getProductDetails(String slug) async {
-    emit(state.copyWith(productDetailsStatus: UsecaseStatus.running));
+    emit(state.copyWith(
+      productDetailsStatus: UsecaseStatus.running,
+      productDetails: const ApiResponse(data: null),
+    ));
     final result = await getProductDetailsUsecase(slug);
     result.fold(
       (failure) => emit(state.copyWith(


### PR DESCRIPTION
This PR updates the `getProductDetails` method in the `ProductCubit` to set the `productDetailsStatus` to `UsecaseStatus.running` and the `productDetails` to `ApiResponse(data: null)` before fetching the product details. This ensures that the UI reflects the loading state correctly.