### PR TITLE
Fix date parsing in multiple model classes

### DIFF
--- a/lib/features/ad/data/models/ad_model.dart
+++ b/lib/features/ad/data/models/ad_model.dart
@@ -21,7 +21,7 @@ class AdModel extends Ad {
       type: MediaType.fromString(map['type']),
       order: map['order'],
       media: map['media'],
-      createdAt: DateFormat(ApiConstants.dateFormat).parse(map['created_at']),
+      createdAt: DateFormat(ApiConstants.dateFormat, 'en_US').parse(map['created_at']),
     );
   }
 
@@ -49,7 +49,7 @@ class AdModel extends Ad {
       'type': type.name,
       'order': order,
       'media': media,
-      'created_at': DateFormat(ApiConstants.dateFormat).format(createdAt),
+      'created_at': DateFormat(ApiConstants.dateFormat, 'en_US').format(createdAt),
     };
   }
 

--- a/lib/features/brand/data/models/brand_model.dart
+++ b/lib/features/brand/data/models/brand_model.dart
@@ -22,7 +22,7 @@ class BrandModel extends Brand {
       id: map['id'],
       name: (map["name"] as String).capitalize,
       media: map['media'],
-      createdAt: DateFormat(ApiConstants.dateFormat).parse(map['created_at']),
+      createdAt: DateFormat(ApiConstants.dateFormat, 'en_US').parse(map['created_at']),
     );
   }
 
@@ -33,7 +33,7 @@ class BrandModel extends Brand {
       "id": id,
       "name": name,
       "media": media,
-      "created_at": DateFormat(ApiConstants.dateFormat).format(createdAt),
+      "created_at": DateFormat(ApiConstants.dateFormat, 'en_US').format(createdAt),
     };
   }
 

--- a/lib/features/cart/data/models/cart_model.dart
+++ b/lib/features/cart/data/models/cart_model.dart
@@ -32,7 +32,7 @@ class CartModel extends Cart {
       isValidQuantity: map['is_valid_quantity'],
       itemTotal: map['item_total'],
       options: List<OptionModel>.from(map['options'].map((x) => OptionModel.fromMap(x))),
-      createdAt: DateFormat(ApiConstants.dateFormat).parse(map['created_at']),
+      createdAt: DateFormat(ApiConstants.dateFormat, 'en_US').parse(map['created_at']),
       product: ProductModel.fromMap(map['product']),
       brand: DropdownItemModel.fromMap(map['Brand']),
     );
@@ -49,7 +49,7 @@ class CartModel extends Cart {
       'Brand': DropdownItemModel.fromDropdown(brand).toMap(),
       "options": options.map((x) => OptionModel.fromOption(x).toMap()).toList(),
       "item_total": itemTotal,
-      "created_at": DateFormat(ApiConstants.dateFormat).format(createdAt),
+      "created_at": DateFormat(ApiConstants.dateFormat, 'en_US').format(createdAt),
     };
   }
 

--- a/lib/features/category/data/models/category_model.dart
+++ b/lib/features/category/data/models/category_model.dart
@@ -33,7 +33,7 @@ class CategoryModel extends Category {
       active: map['active'],
       slug: map['slug'],
       image: map['image'],
-      createdAt: DateFormat(ApiConstants.dateFormat).parse(map['created_at']),
+      createdAt: DateFormat(ApiConstants.dateFormat, 'en_US').parse(map['created_at']),
       children: List<SubCategoryModel>.from(map['children'].map((e) => SubCategoryModel.fromMap(e))),
     );
   }
@@ -48,7 +48,7 @@ class CategoryModel extends Category {
       'active': active,
       'slug': slug,
       'image': image,
-      'created_at': DateFormat(ApiConstants.dateFormat).format(createdAt),
+      'created_at': DateFormat(ApiConstants.dateFormat, 'en_US').format(createdAt),
       'children': List<Map<String, dynamic>>.from(children.map((e) => SubCategoryModel.fromSubCategory(e).toMap()))
     };
   }

--- a/lib/features/category/presentation/widgets/categories_lisview_widget.dart
+++ b/lib/features/category/presentation/widgets/categories_lisview_widget.dart
@@ -22,14 +22,17 @@ class CategoriesListViewWidget extends StatelessWidget {
           return Center(child: Text(LocaleKeys.empty_sub_categories.tr())).asSliver;
         }
 
-        return SliverList.separated(
-          itemBuilder: (context, index) {
-            if (isLoading) return CategoryWithSubsCard.skeleton();
-            final category = state.categories[index];
-            return CategoryWithSubsCard(category);
-          },
-          separatorBuilder: (context, index) => SizedBox(height: 16.h),
-          itemCount: isLoading ? 2 : state.categories.length,
+        return SliverPadding(
+          padding: REdgeInsets.only(bottom: context.bottomBarHeight + 16.h),
+          sliver: SliverList.separated(
+            itemBuilder: (context, index) {
+              if (isLoading) return CategoryWithSubsCard.skeleton();
+              final category = state.categories[index];
+              return CategoryWithSubsCard(category);
+            },
+            separatorBuilder: (context, index) => SizedBox(height: 16.h),
+            itemCount: isLoading ? 2 : state.categories.length,
+          ),
         );
       },
     );

--- a/lib/features/main/presentation/pages/main_tab_page.dart
+++ b/lib/features/main/presentation/pages/main_tab_page.dart
@@ -63,20 +63,17 @@ class _MainTabPageBodyState extends State<MainTabPageBody> {
       ),
       body: RefreshIndicator.adaptive(
         onRefresh: () => _onRefresh(context),
-        child: Padding(
-          padding: REdgeInsets.only(bottom: context.bottomBarHeight + 16.h),
-          child: CustomScrollView(
-            slivers: [
-              SliverList.list(
-                children: [
-                  SizedBox(height: 16.h),
-                  const AdsScrollingWidget(),
-                  const BrandsHorizontalList(),
-                ].withSpacing(spacing: 16.h),
-              ),
-              const CategoriesListViewWidget(),
-            ],
-          ),
+        child: CustomScrollView(
+          slivers: [
+            SliverList.list(
+              children: [
+                SizedBox(height: 16.h),
+                const AdsScrollingWidget(),
+                const BrandsHorizontalList(),
+              ].withSpacing(spacing: 16.h),
+            ),
+            const CategoriesListViewWidget(),
+          ],
         ),
       ),
     );

--- a/lib/features/main/presentation/presentation_imports.dart
+++ b/lib/features/main/presentation/presentation_imports.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:medina_stores/config/resources/locale_keys.g.dart';
-import 'package:medina_stores/core/extensions/context.dart';
 import 'package:medina_stores/core/extensions/spaced_column.dart';
 import 'package:medina_stores/core/navigation/navigator.dart';
 import 'package:medina_stores/features/ad/presentation/presentation_imports.dart';

--- a/lib/features/product/data/models/product_data_model.dart
+++ b/lib/features/product/data/models/product_data_model.dart
@@ -53,7 +53,7 @@ class ProductDataModel extends ProductData {
       optionName: DropdownItemModel.fromMap(map["option_name"]),
       priceAfterDiscount: map["price_after_discount"],
       images: List<ImageModel>.from(map["images"].map((x) => ImageModel.fromMap(x))),
-      createdAt: DateFormat(ApiConstants.dateFormat).parse(map["created_at"]),
+      createdAt: DateFormat(ApiConstants.dateFormat, 'en_US').parse(map["created_at"]),
     );
   }
 
@@ -70,7 +70,7 @@ class ProductDataModel extends ProductData {
         "option_name": (optionName as DropdownItemModel).toMap(),
         "price_after_discount": priceAfterDiscount,
         "images": List<Map<String, dynamic>>.from(images.map((x) => (x as ImageModel).toMap())),
-        "created_at": DateFormat(ApiConstants.dateFormat).format(createdAt),
+        "created_at": DateFormat(ApiConstants.dateFormat, 'en_US').format(createdAt),
       };
 }
 
@@ -99,14 +99,14 @@ class ImageModel extends Image {
         id: map["id"],
         isMain: map["is_main"],
         image: map["image"],
-        createdAt: DateFormat(ApiConstants.dateFormat).parse(map["created_at"]),
+        createdAt: DateFormat(ApiConstants.dateFormat, 'en_US').parse(map["created_at"]),
       );
 
   Map<String, dynamic> toMap() => {
         "id": id,
         "is_main": isMain,
         "image": image,
-        "created_at": DateFormat(ApiConstants.dateFormat).format(createdAt),
+        "created_at": DateFormat(ApiConstants.dateFormat, 'en_US').format(createdAt),
       };
 
   @override

--- a/lib/features/product/data/models/product_model.dart
+++ b/lib/features/product/data/models/product_model.dart
@@ -27,7 +27,7 @@ class ProductModel extends Product {
       price: json['price'] as num,
       priceAfterDiscount: json['price_after_discount'] as num,
       isFavourite: (json['is_favourite'] == 1),
-      createdAt: DateFormat(ApiConstants.dateFormat).parse(json['created_at'] as String),
+      createdAt: DateFormat(ApiConstants.dateFormat, 'en_US').parse(json['created_at'] as String),
     );
   }
 

--- a/lib/features/product/data/models/product_model.dart
+++ b/lib/features/product/data/models/product_model.dart
@@ -59,7 +59,7 @@ class ProductModel extends Product {
       'price': price,
       'price_after_discount': priceAfterDiscount,
       'is_favourite': isFavourite ? 1 : 0,
-      'created_at': DateFormat(ApiConstants.dateFormat).format(createdAt),
+      'created_at': DateFormat(ApiConstants.dateFormat, 'en_US').format(createdAt),
     };
   }
 

--- a/lib/features/sub_category/data/models/sub_category_model.dart
+++ b/lib/features/sub_category/data/models/sub_category_model.dart
@@ -31,7 +31,7 @@ class SubCategoryModel extends SubCategory {
       active: map['active'],
       slug: map['slug'],
       image: map['image'],
-      createdAt: DateFormat(ApiConstants.dateFormat).parse(map['created_at']),
+      createdAt: DateFormat(ApiConstants.dateFormat, 'en_US').parse(map['created_at']),
     );
   }
 
@@ -45,7 +45,7 @@ class SubCategoryModel extends SubCategory {
       'active': active,
       'slug': slug,
       'image': image,
-      'created_at': DateFormat(ApiConstants.dateFormat).format(createdAt),
+      'created_at': DateFormat(ApiConstants.dateFormat, 'en_US').format(createdAt),
     };
   }
 


### PR DESCRIPTION
This pull request fixes the date parsing in multiple model classes (ProductModel, AdModel, BrandModel, CartModel, CategoryModel, ProductDataModel, and SubCategoryModel). Previously, the date parsing was missing the 'en_US' locale parameter in the DateFormat constructor, causing issues with date parsing. This fix adds the 'en_US' locale to ensure correct date parsing according to the specified format.