### PR TITLE
Add support for displaying item options in CartItemWidget

### DIFF
--- a/lib/features/cart/presentation/widgets/cart_item_widget.dart
+++ b/lib/features/cart/presentation/widgets/cart_item_widget.dart
@@ -43,6 +43,18 @@ class CartItemWidget extends StatelessWidget {
                       fontWeight: FontWeight.w600,
                     ),
                   ),
+                  if (item.options.isNotEmpty) ...[
+                    ...item.options.map(
+                      (option) => Text(
+                        option.optionName.name,
+                        style: TextStyle(
+                          fontSize: 14.sp,
+                          fontWeight: FontWeight.w500,
+                          color: context.colorPalette.secondaryText,
+                        ),
+                      ),
+                    ),
+                  ],
                   Text(
                     !item.isValidQuantity ? LocaleKeys.not_available_now.tr() : "${item.itemTotal} ${LocaleKeys.shorten_currency.tr()}",
                     style: TextStyle(


### PR DESCRIPTION
This pull request adds support for displaying item options in the `CartItemWidget`. Previously, the widget only displayed the item name and price. With this change, if an item has options, such as size or color, they will now be displayed below the item name. This provides a more detailed view of the items in the cart.