### PR TITLE
Refactor text styles and themes to use font family constant

### DIFF
--- a/lib/config/text_styles/app_text_styles.dart
+++ b/lib/config/text_styles/app_text_styles.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:medina_stores/core/standards/app_constants.dart';
 
 import '../resources/color_palettes/color_palette.dart';
 import 'app_font_weights.dart';
@@ -34,35 +35,37 @@ class LightAppTextStyles implements AppTextStyle {
 
   const LightAppTextStyles(this.colorPalette);
 
-  @override
-  TextStyle get appBarTitleStyle => const TextStyle(fontSize: 20, color: ColorPalette.blackColor);
-  @override
-  TextStyle get labelTextStyle => const TextStyle(fontSize: 14, color: ColorPalette.blackColor);
-  @override
-  TextStyle get hintTextStyle => const TextStyle(fontSize: 14, color: ColorPalette.blackColor);
-  @override
-  TextStyle get fieldStyle => const TextStyle(fontSize: 14, color: ColorPalette.blackColor);
-  @override
-  TextStyle get mandatoryStyle => const TextStyle(fontSize: 12, fontWeight: AppFontWeight.bold, color: Colors.red);
-  @override
-  TextStyle get errorStyle => TextStyle(fontSize: 12, fontWeight: AppFontWeight.regular, color: colorPalette.error);
-  @override
-  TextStyle get optionalStyle => const TextStyle(fontSize: 12, fontWeight: AppFontWeight.regular, color: ColorPalette.blackColor);
+  TextStyle get _baseStyle => const TextStyle(fontFamily: AppConstants.fontFamily);
 
   @override
-  TextStyle get elevatedButtonTextStyle => TextStyle(fontSize: 14.sp, fontWeight: AppFontWeight.bold);
+  TextStyle get appBarTitleStyle => _baseStyle.copyWith(fontSize: 20, color: ColorPalette.blackColor);
   @override
-  TextStyle get disabledElevatedButtonStyle => TextStyle(fontSize: 14.sp, fontWeight: AppFontWeight.bold);
+  TextStyle get labelTextStyle => _baseStyle.copyWith(fontSize: 14, color: ColorPalette.blackColor);
+  @override
+  TextStyle get hintTextStyle => _baseStyle.copyWith(fontSize: 14, color: ColorPalette.blackColor);
+  @override
+  TextStyle get fieldStyle => _baseStyle.copyWith(fontSize: 14, color: ColorPalette.blackColor);
+  @override
+  TextStyle get mandatoryStyle => _baseStyle.copyWith(fontSize: 12, fontWeight: AppFontWeight.bold, color: Colors.red);
+  @override
+  TextStyle get errorStyle => _baseStyle.copyWith(fontSize: 12, fontWeight: AppFontWeight.regular, color: colorPalette.error);
+  @override
+  TextStyle get optionalStyle => _baseStyle.copyWith(fontSize: 12, fontWeight: AppFontWeight.regular, color: ColorPalette.blackColor);
 
   @override
-  TextStyle get textButtonTextStyle => TextStyle(fontSize: 14.sp, fontWeight: AppFontWeight.bold);
+  TextStyle get elevatedButtonTextStyle => _baseStyle.copyWith(fontSize: 14.sp, fontWeight: AppFontWeight.bold);
   @override
-  TextStyle get textButtonDisabledTextStyle => TextStyle(fontSize: 14.sp, fontWeight: AppFontWeight.bold);
+  TextStyle get disabledElevatedButtonStyle => _baseStyle.copyWith(fontSize: 14.sp, fontWeight: AppFontWeight.bold);
 
   @override
-  TextStyle get bottomNavigationSelectedLabelStyle => const TextStyle(fontSize: 12, fontWeight: AppFontWeight.bold);
+  TextStyle get textButtonTextStyle => _baseStyle.copyWith(fontSize: 14.sp, fontWeight: AppFontWeight.bold);
   @override
-  TextStyle get bottomNavigationUnselectedLabelStyle => const TextStyle(fontSize: 12, fontWeight: AppFontWeight.bold);
+  TextStyle get textButtonDisabledTextStyle => _baseStyle.copyWith(fontSize: 14.sp, fontWeight: AppFontWeight.bold);
+
+  @override
+  TextStyle get bottomNavigationSelectedLabelStyle => _baseStyle.copyWith(fontSize: 12, fontWeight: AppFontWeight.bold);
+  @override
+  TextStyle get bottomNavigationUnselectedLabelStyle => _baseStyle.copyWith(fontSize: 12, fontWeight: AppFontWeight.bold);
 }
 
 class DarkAppTextStyles implements AppTextStyle {
@@ -70,33 +73,35 @@ class DarkAppTextStyles implements AppTextStyle {
 
   const DarkAppTextStyles(this.colorPalette);
 
-  @override
-  TextStyle get appBarTitleStyle => const TextStyle(fontSize: 20, color: ColorPalette.whiteColor);
-  @override
-  TextStyle get labelTextStyle => const TextStyle(fontSize: 14, color: ColorPalette.whiteColor);
-  @override
-  TextStyle get hintTextStyle => const TextStyle(fontSize: 14, color: ColorPalette.whiteColor);
-  @override
-  TextStyle get fieldStyle => const TextStyle(fontSize: 14, color: ColorPalette.whiteColor);
-  @override
-  TextStyle get mandatoryStyle => const TextStyle(fontSize: 12, fontWeight: AppFontWeight.bold, color: Colors.red);
-  @override
-  TextStyle get errorStyle => TextStyle(fontSize: 12, fontWeight: AppFontWeight.regular, color: colorPalette.error);
-  @override
-  TextStyle get optionalStyle => const TextStyle(fontSize: 12, fontWeight: AppFontWeight.regular, color: ColorPalette.whiteColor);
+  TextStyle get _baseStyle => const TextStyle(fontFamily: AppConstants.fontFamily);
 
   @override
-  TextStyle get elevatedButtonTextStyle => TextStyle(fontSize: 14.sp, fontWeight: AppFontWeight.bold);
+  TextStyle get appBarTitleStyle => _baseStyle.copyWith(fontSize: 20, color: ColorPalette.whiteColor);
   @override
-  TextStyle get disabledElevatedButtonStyle => TextStyle(fontSize: 14.sp, fontWeight: AppFontWeight.bold);
+  TextStyle get labelTextStyle => _baseStyle.copyWith(fontSize: 14, color: ColorPalette.whiteColor);
+  @override
+  TextStyle get hintTextStyle => _baseStyle.copyWith(fontSize: 14, color: ColorPalette.whiteColor);
+  @override
+  TextStyle get fieldStyle => _baseStyle.copyWith(fontSize: 14, color: ColorPalette.whiteColor);
+  @override
+  TextStyle get mandatoryStyle => _baseStyle.copyWith(fontSize: 12, fontWeight: AppFontWeight.bold, color: Colors.red);
+  @override
+  TextStyle get errorStyle => _baseStyle.copyWith(fontSize: 12, fontWeight: AppFontWeight.regular, color: colorPalette.error);
+  @override
+  TextStyle get optionalStyle => _baseStyle.copyWith(fontSize: 12, fontWeight: AppFontWeight.regular, color: ColorPalette.whiteColor);
 
   @override
-  TextStyle get textButtonTextStyle => TextStyle(fontSize: 14.sp, fontWeight: AppFontWeight.bold);
+  TextStyle get elevatedButtonTextStyle => _baseStyle.copyWith(fontSize: 14.sp, fontWeight: AppFontWeight.bold);
   @override
-  TextStyle get textButtonDisabledTextStyle => TextStyle(fontSize: 14.sp, fontWeight: AppFontWeight.bold);
+  TextStyle get disabledElevatedButtonStyle => _baseStyle.copyWith(fontSize: 14.sp, fontWeight: AppFontWeight.bold);
 
   @override
-  TextStyle get bottomNavigationSelectedLabelStyle => const TextStyle(fontSize: 12, fontWeight: AppFontWeight.bold);
+  TextStyle get textButtonTextStyle => _baseStyle.copyWith(fontSize: 14.sp, fontWeight: AppFontWeight.bold);
   @override
-  TextStyle get bottomNavigationUnselectedLabelStyle => const TextStyle(fontSize: 12, fontWeight: AppFontWeight.bold);
+  TextStyle get textButtonDisabledTextStyle => _baseStyle.copyWith(fontSize: 14.sp, fontWeight: AppFontWeight.bold);
+
+  @override
+  TextStyle get bottomNavigationSelectedLabelStyle => _baseStyle.copyWith(fontSize: 12, fontWeight: AppFontWeight.bold);
+  @override
+  TextStyle get bottomNavigationUnselectedLabelStyle => _baseStyle.copyWith(fontSize: 12, fontWeight: AppFontWeight.bold);
 }

--- a/lib/config/themes/app_themes.dart
+++ b/lib/config/themes/app_themes.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:medina_stores/core/standards/app_constants.dart';
 
 import '../resources/color_palettes/color_palette.dart';
 import '../text_styles/app_text_styles.dart';

--- a/lib/config/themes/light_theme.dart
+++ b/lib/config/themes/light_theme.dart
@@ -5,8 +5,8 @@ ThemeData lightTheme(
   AppTextStyle appTextStyle,
 ) {
   return ThemeData(
-    fontFamily: 'ReadexPro',
-    fontFamilyFallback: const ['ReadexPro'],
+    fontFamily: AppConstants.fontFamily,
+    fontFamilyFallback: const [AppConstants.fontFamily],
     brightness: Brightness.light,
     primaryColor: palette.primary,
     primaryColorDark: palette.primaryVariant,

--- a/lib/core/standards/app_constants.dart
+++ b/lib/core/standards/app_constants.dart
@@ -1,0 +1,3 @@
+class AppConstants {
+  static const String fontFamily = 'ReadexPro';
+}

--- a/lib/features/user/presentation/presentation_imports.dart
+++ b/lib/features/user/presentation/presentation_imports.dart
@@ -17,6 +17,7 @@ import 'package:medina_stores/core/helpers/message_helper.dart';
 import 'package:medina_stores/core/helpers/validation_helper.dart';
 import 'package:medina_stores/core/shared_widgets/core_widgets/app_textfield.dart';
 import 'package:medina_stores/core/shared_widgets/state_managers/loading_manager.dart';
+import 'package:medina_stores/core/standards/app_constants.dart';
 import 'package:medina_stores/core/standards/response_model.dart';
 import 'package:medina_stores/features/layout/presentation/presentation_imports.dart';
 import 'package:pinput/pinput.dart';

--- a/lib/features/user/presentation/widgets/register_now_widget.dart
+++ b/lib/features/user/presentation/widgets/register_now_widget.dart
@@ -18,8 +18,8 @@ class RegisterNowWidget extends StatelessWidget {
             style: TextStyle(
               fontWeight: AppFontWeight.regular,
               fontSize: 12.sp,
-              fontFamily: 'Kaff',
               color: palette.hintText,
+              fontFamily: AppConstants.fontFamily,
             ),
           ),
           const TextSpan(text: ' '),
@@ -29,6 +29,7 @@ class RegisterNowWidget extends StatelessWidget {
               fontWeight: AppFontWeight.regular,
               fontSize: 12.sp,
               decoration: TextDecoration.underline,
+              fontFamily: AppConstants.fontFamily,
               color: palette.secondary,
             ),
             recognizer: TapGestureRecognizer()..onTap = () => AppNavigator.to(const RegisterScreen()),


### PR DESCRIPTION
Refactor the text styles and themes to use the `AppConstants` font family constant. This ensures consistency across the application and makes it easier to update the font family in the future.