### PR TITLE
Add flutter_html package for rendering HTML content

### DIFF
--- a/assets/translations/ar.json
+++ b/assets/translations/ar.json
@@ -115,5 +115,16 @@
   "product_search_by": "البحث بـ اسم المنتج او العلامة التجارية او القسم",
   "edit": "تعديل",
   "profile": "الملف الشخصي",
-  "wallet": "المحفظة"
+  "account": "الحساب",
+  "wallet": "المحفظة",
+  "help": "المساعدة",
+  "settings": "الإعدادات",
+  "about_us": "من نحن",
+  "contact_us": "اتصل بنا",
+  "license": "الترخيص",
+  "privacy_policy": "سياسة الخصوصية",
+  "terms_and_conditions": "الشروط والأحكام",
+  "shipping_policy": "سياسة الشحن",
+  "select_language": "اختر اللغة",
+  "confirm": "تأكيد"
 }

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -116,5 +116,16 @@
   "product_search_by": "Search by product name, brand or category",
   "edit": "Edit",
   "profile": "Profile",
-  "wallet": "Wallet"
+  "account": "Account",
+  "wallet": "Wallet",
+  "help": "Help",
+  "settings": "Settings",
+  "about_us": "About Us",
+  "contact_us": "Contact Us",
+  "license": "License",
+  "privacy_policy": "Privacy Policy",
+  "terms_and_conditions": "Terms and Conditions",
+  "shipping_policy": "Shipping Policy",
+  "select_language": "Select Language",
+  "confirm": "Confirm"
 }

--- a/lib/config/resources/locale_keys.g.dart
+++ b/lib/config/resources/locale_keys.g.dart
@@ -120,5 +120,16 @@ abstract class LocaleKeys {
   static const product_search_by = 'product_search_by';
   static const edit = 'edit';
   static const profile = 'profile';
+  static const account = 'account';
   static const wallet = 'wallet';
+  static const help = 'help';
+  static const settings = 'settings';
+  static const about_us = 'about_us';
+  static const contact_us = 'contact_us';
+  static const license = 'license';
+  static const privacy_policy = 'privacy_policy';
+  static const terms_and_conditions = 'terms_and_conditions';
+  static const shipping_policy = 'shipping_policy';
+  static const select_language = 'select_language';
+  static const confirm = 'confirm';
 }

--- a/lib/core/helpers/cache_helper.dart
+++ b/lib/core/helpers/cache_helper.dart
@@ -18,6 +18,7 @@ class CacheKeys {
   static const String userAddresses = 'user-addresses';
   static const String latestProducts = 'latest-products';
   static const String favoriteProducts = 'favorite-products';
+  static const String staticPages = 'static-pages';
 }
 
 class CacheHelper {

--- a/lib/core/helpers/dependency_helper.dart
+++ b/lib/core/helpers/dependency_helper.dart
@@ -1,4 +1,5 @@
 import 'package:get_it/get_it.dart';
+import '../../features/static_page/di/setup_static_page_dependencies.dart';
 import 'package:internet_connection_checker/internet_connection_checker.dart';
 
 import '../../features/ad/di/setup_ad_dependencies.dart';
@@ -23,6 +24,7 @@ class DependencyHelper {
 
   void registerDependencies() {
     setUpGeneralDependencies();
+    setUpStaticPageDependencies();
     setUpAddressDependencies();
     setUpCartDependencies();
     setUpProductDependencies();

--- a/lib/core/networking/api_constants.dart
+++ b/lib/core/networking/api_constants.dart
@@ -32,6 +32,14 @@ class ApiEndPoints {
   final String DELETE_ACCOUNT = '/profile/delete-account';
   final String UPDATE_PASSWORD = '/profile/update-password';
 
+  // Settings
+  final String TERMS = '/settings/terms';
+  final String PRIVACY = '/settings/privacy-policy';
+  final String ABOUT = '/settings/about';
+  final String CONTACT = '/settings/contact-us';
+  final String SHIPPING = '/settings/shipping-policy';
+  final String LICENSE = '/settings/license';
+
   // Auth
   final String login = '/login';
   final String register = '/register';

--- a/lib/features/brand/data/datasources/brand_local_data_source.dart
+++ b/lib/features/brand/data/datasources/brand_local_data_source.dart
@@ -10,13 +10,9 @@ class BrandLocalDataSourceImpl implements BrandLocalDataSource {
 
   @override
   Future<List<BrandModel>> getCachedBrands() async {
-    // try {
     final jsonString = await CacheHelper.read(CacheKeys.brands);
     final jsonList = json.decode(jsonString) as List;
     return List<BrandModel>.from(jsonList.map((json) => BrandModel.fromMap(json)));
-    // } catch (e) {
-    //   throw CacheException(ApiResponse(message: e.toString()));
-    // }
   }
 
   @override

--- a/lib/features/language/presentation/presentation_imports.dart
+++ b/lib/features/language/presentation/presentation_imports.dart
@@ -1,8 +1,13 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:medina_stores/core/extensions/context.dart';
+import 'package:medina_stores/core/navigation/navigator.dart';
 
 import '../../../config/resources/languages.dart';
+import '../../../config/resources/locale_keys.g.dart';
 
 part 'cubit/language_cubit.dart';
+part 'widgets/languages_dialog_widget.dart';
 part 'widgets/languages_dropdown_widget.dart';

--- a/lib/features/language/presentation/widgets/languages_dialog_widget.dart
+++ b/lib/features/language/presentation/widgets/languages_dialog_widget.dart
@@ -1,0 +1,99 @@
+part of '../presentation_imports.dart';
+
+class LanguageDialogWidget extends StatelessWidget {
+  const LanguageDialogWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<LanguageCubit, Language>(
+      builder: (context, selectedLang) {
+        return ListTile(
+          onTap: () async {
+            final selectedLanguage = await showDialog<Language>(
+              context: context,
+              builder: (BuildContext context) => const _DialogWidget(),
+            );
+
+            if (selectedLanguage != null && context.mounted) {
+              if (selectedLang == selectedLanguage) return;
+              context.read<LanguageCubit>().changeLanguage(context, selectedLanguage);
+            }
+          },
+          title: Text(
+            selectedLang.locale.languageCode.tr(context: context),
+            style: context.appTextStyle.optionalStyle.copyWith(
+              fontSize: 14.sp,
+            ),
+          ),
+          leading: const Icon(Icons.language),
+          trailing: Icon(Icons.arrow_forward_ios, size: 16.sp),
+        );
+      },
+    );
+  }
+}
+
+class _DialogWidget extends StatefulWidget {
+  const _DialogWidget();
+
+  @override
+  State<_DialogWidget> createState() => _DialogWidgetState();
+}
+
+class _DialogWidgetState extends State<_DialogWidget> {
+  final ValueNotifier<Language> _selectedLanguage = ValueNotifier(Language.arabic);
+
+  @override
+  void initState() {
+    _selectedLanguage.value = context.read<LanguageCubit>().state;
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder(
+      valueListenable: _selectedLanguage,
+      builder: (context, selectedLang, child) {
+        return AlertDialog(
+          insetPadding: REdgeInsets.symmetric(horizontal: 16),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16.r),
+          ),
+          title: Text(LocaleKeys.select_language.tr()),
+          content: SizedBox(
+            width: 1.sw - 32.w,
+            height: 0.1.sh,
+            child: ListView.builder(
+              shrinkWrap: true,
+              itemCount: Language.values.length,
+              itemBuilder: (BuildContext context, int index) {
+                final language = Language.values[index];
+                return ListTile(
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8.r),
+                  ),
+                  title: Text(language.languageCode.tr()),
+                  tileColor: selectedLang == language ? context.colorPalette.cardShadow : null,
+                  trailing: selectedLang == language ? Icon(Icons.check_circle_outline, color: context.colorPalette.primary) : null,
+                  onTap: () {
+                    _selectedLanguage.value = language;
+                  },
+                );
+              },
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => AppNavigator.pop(),
+              child: Text(LocaleKeys.cancel.tr()),
+            ),
+            TextButton(
+              onPressed: () => AppNavigator.pop(_selectedLanguage.value),
+              child: Text(LocaleKeys.confirm.tr()),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/features/me/presentation/pages/me_tab.dart
+++ b/lib/features/me/presentation/pages/me_tab.dart
@@ -52,7 +52,7 @@ class _MeTabState extends State<MeTab> {
                 icon: Icon(Icons.arrow_forward_ios, size: 14.sp),
                 iconAlignment: IconAlignment.end,
                 label: Text(
-                  LocaleKeys.edit.tr(),
+                  LocaleKeys.edit.tr(context: context),
                   style: TextStyle(color: context.colorPalette.primary),
                 ),
               ),
@@ -61,21 +61,21 @@ class _MeTabState extends State<MeTab> {
           body: Padding(
             padding: REdgeInsets.all(16.0),
             child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                ListTile(
-                  onTap: () => AppNavigator.to(const UpdateProfilePage()),
-                  title: Text(
-                    LocaleKeys.profile.tr(),
-                    style: context.appTextStyle.optionalStyle.copyWith(
-                      fontSize: 14.sp,
+                Padding(
+                  padding: REdgeInsets.all(16.0),
+                  child: Text(
+                    LocaleKeys.account.tr(context: context),
+                    style: TextStyle(
+                      fontSize: 16.sp,
+                      fontWeight: FontWeight.bold,
                     ),
                   ),
-                  leading: const Icon(Icons.person),
-                  trailing: Icon(Icons.arrow_forward_ios, size: 16.sp),
                 ),
                 ListTile(
                   title: Text(
-                    LocaleKeys.wallet.tr(),
+                    LocaleKeys.wallet.tr(context: context),
                     style: context.appTextStyle.optionalStyle.copyWith(
                       fontSize: 14.sp,
                     ),
@@ -91,7 +91,7 @@ class _MeTabState extends State<MeTab> {
                           borderRadius: BorderRadius.circular(8.r),
                         ),
                         child: Text(
-                          '${data.wallet} ${LocaleKeys.shorten_currency.tr()} ',
+                          '${data.wallet} ${LocaleKeys.shorten_currency.tr(context: context)} ',
                           style: context.appTextStyle.elevatedButtonTextStyle.copyWith(
                             fontSize: 14.sp,
                           ),
@@ -104,12 +104,89 @@ class _MeTabState extends State<MeTab> {
                 ListTile(
                   onTap: () => AppNavigator.to(const ChangePasswordPage()),
                   title: Text(
-                    LocaleKeys.change_password.tr(),
+                    LocaleKeys.change_password.tr(context: context),
                     style: context.appTextStyle.optionalStyle.copyWith(
                       fontSize: 14.sp,
                     ),
                   ),
                   leading: const Icon(Icons.lock),
+                  trailing: Icon(Icons.arrow_forward_ios, size: 16.sp),
+                ),
+                const LanguageDialogWidget(),
+                Padding(
+                  padding: REdgeInsets.all(16.0),
+                  child: Text(
+                    LocaleKeys.help.tr(context: context),
+                    style: TextStyle(
+                      fontSize: 16.sp,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                ListTile(
+                  onTap: () => AppNavigator.to(const PrivacyPolicyPage()),
+                  title: Text(
+                    LocaleKeys.privacy_policy.tr(context: context),
+                    style: context.appTextStyle.optionalStyle.copyWith(
+                      fontSize: 14.sp,
+                    ),
+                  ),
+                  leading: const Icon(Icons.privacy_tip),
+                  trailing: Icon(Icons.arrow_forward_ios, size: 16.sp),
+                ),
+                ListTile(
+                  onTap: () => AppNavigator.to(const ShippingPolicyPage()),
+                  title: Text(
+                    LocaleKeys.shipping_policy.tr(context: context),
+                    style: context.appTextStyle.optionalStyle.copyWith(
+                      fontSize: 14.sp,
+                    ),
+                  ),
+                  leading: const Icon(Icons.privacy_tip),
+                  trailing: Icon(Icons.arrow_forward_ios, size: 16.sp),
+                ),
+                ListTile(
+                  onTap: () => AppNavigator.to(const TermsPage()),
+                  title: Text(
+                    LocaleKeys.terms_and_conditions.tr(context: context),
+                    style: context.appTextStyle.optionalStyle.copyWith(
+                      fontSize: 14.sp,
+                    ),
+                  ),
+                  leading: const Icon(Icons.privacy_tip),
+                  trailing: Icon(Icons.arrow_forward_ios, size: 16.sp),
+                ),
+                ListTile(
+                  onTap: () => AppNavigator.to(const AboutUsPage()),
+                  title: Text(
+                    LocaleKeys.about_us.tr(context: context),
+                    style: context.appTextStyle.optionalStyle.copyWith(
+                      fontSize: 14.sp,
+                    ),
+                  ),
+                  leading: const Icon(Icons.privacy_tip),
+                  trailing: Icon(Icons.arrow_forward_ios, size: 16.sp),
+                ),
+                ListTile(
+                  onTap: () => AppNavigator.to(const ContactUsPage()),
+                  title: Text(
+                    LocaleKeys.contact_us.tr(context: context),
+                    style: context.appTextStyle.optionalStyle.copyWith(
+                      fontSize: 14.sp,
+                    ),
+                  ),
+                  leading: const Icon(Icons.privacy_tip),
+                  trailing: Icon(Icons.arrow_forward_ios, size: 16.sp),
+                ),
+                ListTile(
+                  onTap: () => AppNavigator.to(const AppLicensePage()),
+                  title: Text(
+                    LocaleKeys.license.tr(context: context),
+                    style: context.appTextStyle.optionalStyle.copyWith(
+                      fontSize: 14.sp,
+                    ),
+                  ),
+                  leading: const Icon(Icons.privacy_tip),
                   trailing: Icon(Icons.arrow_forward_ios, size: 16.sp),
                 ),
               ],

--- a/lib/features/me/presentation/presentation_imports.dart
+++ b/lib/features/me/presentation/presentation_imports.dart
@@ -2,12 +2,14 @@ import 'package:easy_localization/easy_localization.dart' hide TextDirection;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:medina_stores/features/language/presentation/presentation_imports.dart';
 
 import '../../../config/resources/locale_keys.g.dart';
 import '../../../core/extensions/context.dart';
 import '../../../core/extensions/spaced_row.dart';
 import '../../../core/navigation/navigator.dart';
 import '../../../core/shared_widgets/core_widgets/main_app_bar.dart';
+import '../../static_page/presentation/presentation_imports.dart';
 import '../../user/domain/domain_imports.dart';
 import '../../user/presentation/presentation_imports.dart';
 

--- a/lib/features/static_page/data/data_imports.dart
+++ b/lib/features/static_page/data/data_imports.dart
@@ -1,0 +1,18 @@
+import 'dart:convert';
+
+import 'package:dartz/dartz.dart';
+import 'package:internet_connection_checker/internet_connection_checker.dart';
+import 'package:medina_stores/core/extensions/failure_type_extension.dart';
+
+import '../../../../core/helpers/dependency_helper.dart';
+import '../../../../core/networking/api_request.dart';
+import '../../../../core/networking/api_service.dart';
+import '../../../core/error/exceptions.dart';
+import '../../../core/error/failures.dart';
+import '../../../core/helpers/cache_helper.dart';
+import '../../../core/standards/response_model.dart';
+import '../domain/domain_imports.dart';
+
+part 'datasources/static_page_local_data_source.dart';
+part 'datasources/static_page_remote_data_source.dart';
+part 'repositories/static_page_repository_impl.dart';

--- a/lib/features/static_page/data/datasources/static_page_local_data_source.dart
+++ b/lib/features/static_page/data/datasources/static_page_local_data_source.dart
@@ -1,0 +1,38 @@
+part of '../data_imports.dart';
+
+abstract class StaticPageLocalDataSource {
+  Future<ApiResponseModel<String>> getStaticPageData(String path);
+  Future<void> cacheStaticPageData(String path, String data);
+}
+
+class StaticPageLocalDataSourceImpl implements StaticPageLocalDataSource {
+  @override
+  Future<void> cacheStaticPageData(String path, String data) async {
+    try {
+      final cachedJson = await CacheHelper.read(CacheKeys.staticPages);
+      if (cachedJson == null) {
+        return await CacheHelper.write(CacheKeys.staticPages, json.encode({path: data}));
+      }
+      final dataAsMap = Map<String, dynamic>.from(jsonDecode(cachedJson));
+      if (dataAsMap.containsKey(path)) {
+        dataAsMap[path] = data;
+      } else {
+        dataAsMap.addAll({path: data});
+      }
+      return await CacheHelper.write(CacheKeys.staticPages, json.encode(dataAsMap));
+    } catch (e) {
+      throw CacheException(ApiResponse(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<ApiResponseModel<String>> getStaticPageData(String path) async {
+    final cachedJson = await CacheHelper.read(CacheKeys.staticPages);
+    final dataAsMap = Map<String, dynamic>.from(jsonDecode(cachedJson));
+    if (dataAsMap.containsKey(path)) {
+      return ApiResponseModel.fromMap(dataAsMap[path]);
+    } else {
+      throw const CacheException(ApiResponse(message: 'No cached data found'));
+    }
+  }
+}

--- a/lib/features/static_page/data/datasources/static_page_remote_data_source.dart
+++ b/lib/features/static_page/data/datasources/static_page_remote_data_source.dart
@@ -1,0 +1,19 @@
+part of '../data_imports.dart';
+
+abstract class StaticPageRemoteDataSource {
+  Future<ApiResponseModel<String>> getStaticPageData(String path);
+}
+
+class StaticPageRemoteDataSourceImpl implements StaticPageRemoteDataSource {
+  @override
+  Future<ApiResponseModel<String>> getStaticPageData(String path) async {
+    final request = ApiRequest(
+      method: RequestMethod.get,
+      path: path,
+    );
+    return await DependencyHelper.instance.get<ApiService>().callApi<String>(
+          request,
+          mapper: (json) => ApiResponseModel.fromMap(json),
+        );
+  }
+}

--- a/lib/features/static_page/data/repositories/static_page_repository_impl.dart
+++ b/lib/features/static_page/data/repositories/static_page_repository_impl.dart
@@ -1,0 +1,40 @@
+part of '../data_imports.dart';
+
+class StaticPageRepositoryImpl implements StaticPageRepository {
+  final InternetConnectionChecker connectionChecker;
+  final StaticPageRemoteDataSource remoteDataSource;
+  final StaticPageLocalDataSource localDataSource;
+
+  const StaticPageRepositoryImpl({
+    required this.remoteDataSource,
+    required this.connectionChecker,
+    required this.localDataSource,
+  });
+
+  @override
+  Future<Either<Failure, ApiResponse<String>>> getStaticPageData(String path) async {
+    if (await connectionChecker.hasConnection) {
+      try {
+        final brands = await remoteDataSource.getStaticPageData(path);
+        await localDataSource.cacheStaticPageData(brands.data!, path);
+        return Right(brands);
+      } on NoInternetConnectionException {
+        try {
+          final data = await localDataSource.getStaticPageData(path);
+          return Right(data);
+        } on CacheException catch (e) {
+          return Left(CacheFailure(response: e.response));
+        }
+      } on AppException catch (e) {
+        return Left(e.handleFailure);
+      }
+    } else {
+      try {
+        final data = await localDataSource.getStaticPageData(path);
+        return Right(data);
+      } on CacheException catch (e) {
+        return Left(CacheFailure(response: e.response));
+      }
+    }
+  }
+}

--- a/lib/features/static_page/di/setup_static_page_dependencies.dart
+++ b/lib/features/static_page/di/setup_static_page_dependencies.dart
@@ -1,0 +1,36 @@
+import '../../../core/helpers/dependency_helper.dart';
+import '../data/data_imports.dart';
+import '../domain/domain_imports.dart';
+import '../presentation/presentation_imports.dart';
+
+void setUpStaticPageDependencies() async {
+  // CUBIT
+  DependencyHelper.instance.serviceLocator.registerFactory(
+    () => StaticPageCubit(
+      getStaticPageUsecase: DependencyHelper.instance.serviceLocator(),
+    ),
+  );
+
+  // USECASES
+  DependencyHelper.instance.serviceLocator.registerLazySingleton(
+    () => GetStaticPagesUsecase(repository: DependencyHelper.instance.serviceLocator()),
+  );
+
+  // REPOSITORIES
+  DependencyHelper.instance.serviceLocator.registerLazySingleton<StaticPageRepository>(
+    () => StaticPageRepositoryImpl(
+      connectionChecker: DependencyHelper.instance.serviceLocator(),
+      remoteDataSource: DependencyHelper.instance.serviceLocator(),
+      localDataSource: DependencyHelper.instance.serviceLocator(),
+    ),
+  );
+
+  // DATASOURCES
+  DependencyHelper.instance.serviceLocator.registerLazySingleton<StaticPageRemoteDataSource>(
+    () => StaticPageRemoteDataSourceImpl(),
+  );
+
+  DependencyHelper.instance.serviceLocator.registerLazySingleton<StaticPageLocalDataSource>(
+    () => StaticPageLocalDataSourceImpl(),
+  );
+}

--- a/lib/features/static_page/domain/domain_imports.dart
+++ b/lib/features/static_page/domain/domain_imports.dart
@@ -1,0 +1,10 @@
+import 'package:dartz/dartz.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../../core/error/failures.dart';
+import '../../../core/standards/response_model.dart';
+import '../../../core/standards/use_case.dart';
+
+part 'entities/static_page.dart';
+part 'repositories/static_page_repository.dart';
+part 'usecases/get_static_pages_usecase.dart';

--- a/lib/features/static_page/domain/entities/static_page.dart
+++ b/lib/features/static_page/domain/entities/static_page.dart
@@ -1,0 +1,32 @@
+part of '../domain_imports.dart';
+
+class StaticPage extends Equatable {
+  final int userId;
+  final int id;
+  final String title;
+  final String body;
+
+  const StaticPage({
+    required this.userId,
+    required this.id,
+    required this.title,
+    required this.body,
+  });
+
+  StaticPage copyWith({
+    int? userId,
+    int? id,
+    String? title,
+    String? body,
+  }) {
+    return StaticPage(
+      userId: userId ?? this.userId,
+      id: id ?? this.id,
+      title: title ?? this.title,
+      body: body ?? this.body,
+    );
+  }
+
+  @override
+  List<Object?> get props => [userId, id, title, body];
+}

--- a/lib/features/static_page/domain/repositories/static_page_repository.dart
+++ b/lib/features/static_page/domain/repositories/static_page_repository.dart
@@ -1,0 +1,5 @@
+part of '../domain_imports.dart';
+
+abstract class StaticPageRepository {
+  Future<Either<Failure, ApiResponse<String>>> getStaticPageData(String path);
+}

--- a/lib/features/static_page/domain/usecases/get_static_pages_usecase.dart
+++ b/lib/features/static_page/domain/usecases/get_static_pages_usecase.dart
@@ -1,0 +1,12 @@
+part of '../domain_imports.dart';
+
+class GetStaticPagesUsecase implements UseCase<ApiResponse<String>, String> {
+  final StaticPageRepository repository;
+
+  const GetStaticPagesUsecase({required this.repository});
+
+  @override
+  Future<Either<Failure, ApiResponse<String>>> call(String param) async {
+    return await repository.getStaticPageData(param);
+  }
+}

--- a/lib/features/static_page/presentation/cubit/static_page_cubit.dart
+++ b/lib/features/static_page/presentation/cubit/static_page_cubit.dart
@@ -1,0 +1,22 @@
+part of '../presentation_imports.dart';
+
+class StaticPageCubit extends Cubit<StaticPageState> {
+  StaticPageCubit({
+    required this.getStaticPageUsecase,
+  }) : super(const StaticPageState());
+
+  final GetStaticPagesUsecase getStaticPageUsecase;
+
+  Future<void> getStaticPage(String path) async {
+    emit(state.copyWith(staticPagesStatus: UsecaseStatus.running));
+    final result = await getStaticPageUsecase(path);
+    result.fold(
+      (failure) {
+        emit(state.copyWith(staticPagesStatus: UsecaseStatus.error, staticPagesFailure: failure));
+      },
+      (staticPage) {
+        emit(state.copyWith(staticPagesStatus: UsecaseStatus.completed, staticPageData: staticPage));
+      },
+    );
+  }
+}

--- a/lib/features/static_page/presentation/cubit/static_page_state.dart
+++ b/lib/features/static_page/presentation/cubit/static_page_state.dart
@@ -1,0 +1,37 @@
+part of '../presentation_imports.dart';
+
+class StaticPageState extends Equatable {
+  const StaticPageState({
+    this.staticPagesStatus = UsecaseStatus.idle,
+    this.staticPagesFailure,
+    this.staticPageData = const ApiResponse(data: ''),
+  });
+
+  final UsecaseStatus staticPagesStatus;
+  final Failure? staticPagesFailure;
+  final ApiResponse<String> staticPageData;
+
+  StaticPageState copyWith({
+    UsecaseStatus? staticPagesStatus,
+    Failure? staticPagesFailure,
+    ApiResponse<String>? staticPageData,
+  }) {
+    return StaticPageState(
+      staticPagesStatus: staticPagesStatus ?? this.staticPagesStatus,
+      staticPagesFailure: staticPagesFailure ?? this.staticPagesFailure,
+      staticPageData: staticPageData ?? this.staticPageData,
+    );
+  }
+
+  @override
+  String toString() {
+    return 'StaticPageState(staticPagesStatus: $staticPagesStatus, staticPagesFailure: $staticPagesFailure, staticPages: $staticPageData)';
+  }
+
+  @override
+  List<Object?> get props => [
+        staticPagesStatus,
+        staticPagesFailure,
+        staticPageData,
+      ];
+}

--- a/lib/features/static_page/presentation/pages/about_us_page.dart
+++ b/lib/features/static_page/presentation/pages/about_us_page.dart
@@ -1,0 +1,31 @@
+part of '../presentation_imports.dart';
+
+class AboutUsPage extends StatelessWidget {
+  const AboutUsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => DependencyHelper.instance.serviceLocator<StaticPageCubit>()..getStaticPage(ApiConstants.endPoints.ABOUT),
+      child: const AboutUsBody(),
+    );
+  }
+}
+
+class AboutUsBody extends StatelessWidget {
+  const AboutUsBody({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: MainAppBar(
+        title: Text(LocaleKeys.about_us.tr()),
+      ),
+      body: StaticPageDataWidget(
+        onRetry: () {
+          context.read<StaticPageCubit>().getStaticPage(ApiConstants.endPoints.ABOUT);
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/static_page/presentation/pages/contact_us_page.dart
+++ b/lib/features/static_page/presentation/pages/contact_us_page.dart
@@ -1,0 +1,31 @@
+part of '../presentation_imports.dart';
+
+class ContactUsPage extends StatelessWidget {
+  const ContactUsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => DependencyHelper.instance.serviceLocator<StaticPageCubit>()..getStaticPage(ApiConstants.endPoints.CONTACT),
+      child: const ContactUsBody(),
+    );
+  }
+}
+
+class ContactUsBody extends StatelessWidget {
+  const ContactUsBody({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: MainAppBar(
+        title: Text(LocaleKeys.about_us.tr()),
+      ),
+      body: StaticPageDataWidget(
+        onRetry: () {
+          context.read<StaticPageCubit>().getStaticPage(ApiConstants.endPoints.CONTACT);
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/static_page/presentation/pages/license_page.dart
+++ b/lib/features/static_page/presentation/pages/license_page.dart
@@ -1,0 +1,31 @@
+part of '../presentation_imports.dart';
+
+class AppLicensePage extends StatelessWidget {
+  const AppLicensePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => DependencyHelper.instance.serviceLocator<StaticPageCubit>()..getStaticPage(ApiConstants.endPoints.LICENSE),
+      child: const LicenseBody(),
+    );
+  }
+}
+
+class LicenseBody extends StatelessWidget {
+  const LicenseBody({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: MainAppBar(
+        title: Text(LocaleKeys.license.tr()),
+      ),
+      body: StaticPageDataWidget(
+        onRetry: () {
+          context.read<StaticPageCubit>().getStaticPage(ApiConstants.endPoints.LICENSE);
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/static_page/presentation/pages/privacy_policy_page.dart
+++ b/lib/features/static_page/presentation/pages/privacy_policy_page.dart
@@ -1,0 +1,31 @@
+part of '../presentation_imports.dart';
+
+class PrivacyPolicyPage extends StatelessWidget {
+  const PrivacyPolicyPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => DependencyHelper.instance.serviceLocator<StaticPageCubit>()..getStaticPage(ApiConstants.endPoints.PRIVACY),
+      child: const PrivacyPolicyBody(),
+    );
+  }
+}
+
+class PrivacyPolicyBody extends StatelessWidget {
+  const PrivacyPolicyBody({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: MainAppBar(
+        title: Text(LocaleKeys.privacy_policy.tr()),
+      ),
+      body: StaticPageDataWidget(
+        onRetry: () {
+          context.read<StaticPageCubit>().getStaticPage(ApiConstants.endPoints.PRIVACY);
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/static_page/presentation/pages/shipping_policy_page.dart
+++ b/lib/features/static_page/presentation/pages/shipping_policy_page.dart
@@ -1,0 +1,31 @@
+part of '../presentation_imports.dart';
+
+class ShippingPolicyPage extends StatelessWidget {
+  const ShippingPolicyPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => DependencyHelper.instance.serviceLocator<StaticPageCubit>()..getStaticPage(ApiConstants.endPoints.SHIPPING),
+      child: const ShippingPolicyBody(),
+    );
+  }
+}
+
+class ShippingPolicyBody extends StatelessWidget {
+  const ShippingPolicyBody({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: MainAppBar(
+        title: Text(LocaleKeys.shipping_policy.tr()),
+      ),
+      body: StaticPageDataWidget(
+        onRetry: () {
+          context.read<StaticPageCubit>().getStaticPage(ApiConstants.endPoints.SHIPPING);
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/static_page/presentation/pages/terms_page.dart
+++ b/lib/features/static_page/presentation/pages/terms_page.dart
@@ -1,0 +1,31 @@
+part of '../presentation_imports.dart';
+
+class TermsPage extends StatelessWidget {
+  const TermsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => DependencyHelper.instance.serviceLocator<StaticPageCubit>()..getStaticPage(ApiConstants.endPoints.TERMS),
+      child: const TermsBody(),
+    );
+  }
+}
+
+class TermsBody extends StatelessWidget {
+  const TermsBody({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: MainAppBar(
+        title: Text(LocaleKeys.terms_and_conditions.tr()),
+      ),
+      body: StaticPageDataWidget(
+        onRetry: () {
+          context.read<StaticPageCubit>().getStaticPage(ApiConstants.endPoints.TERMS);
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/static_page/presentation/presentation_imports.dart
+++ b/lib/features/static_page/presentation/presentation_imports.dart
@@ -1,0 +1,27 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_html/flutter_html.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:medina_stores/config/resources/locale_keys.g.dart';
+import 'package:medina_stores/core/helpers/dependency_helper.dart';
+import 'package:medina_stores/core/helpers/url_launcher_helper.dart';
+import 'package:medina_stores/core/networking/api_constants.dart';
+import 'package:medina_stores/core/shared_widgets/state_managers/error_widget.dart';
+import 'package:medina_stores/core/standards/response_model.dart';
+
+import '../../../core/error/failures.dart';
+import '../../../core/shared_widgets/core_widgets/main_app_bar.dart';
+import '../../../core/standards/usecase_status.dart';
+import '../domain/domain_imports.dart';
+
+part 'cubit/static_page_cubit.dart';
+part 'cubit/static_page_state.dart';
+part 'pages/about_us_page.dart';
+part 'pages/contact_us_page.dart';
+part 'pages/license_page.dart';
+part 'pages/privacy_policy_page.dart';
+part 'pages/shipping_policy_page.dart';
+part 'pages/terms_page.dart';
+part 'widgets/static_page_data_widget.dart';

--- a/lib/features/static_page/presentation/widgets/static_page_data_widget.dart
+++ b/lib/features/static_page/presentation/widgets/static_page_data_widget.dart
@@ -1,0 +1,41 @@
+part of '../presentation_imports.dart';
+
+class StaticPageDataWidget extends StatelessWidget {
+  const StaticPageDataWidget({
+    super.key,
+    required this.onRetry,
+  });
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocSelector<StaticPageCubit, StaticPageState, ({UsecaseStatus status, Failure? failure, String data})>(
+      selector: (state) => (
+        status: state.staticPagesStatus,
+        failure: state.staticPagesFailure,
+        data: state.staticPageData.data!,
+      ),
+      builder: (context, state) {
+        if (state.status == UsecaseStatus.running) {
+          return const Center(child: CircularProgressIndicator.adaptive());
+        }
+
+        if (state.status == UsecaseStatus.error) {
+          return ErrorViewWidget(state.failure!, onRetry: onRetry);
+        }
+
+        return SingleChildScrollView(
+          padding: REdgeInsets.all(20),
+          child: Html(
+            data: state.data,
+            onLinkTap: (url, attributes, element) {
+              if (url == null) return;
+              UrlLauncherHelper.launchURL(Uri.parse(url));
+            },
+          ),
+        );
+      },
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -293,10 +293,10 @@ packages:
     dependency: transitive
     description:
       name: csslib
-      sha256: "706b5707578e0c1b4b7550f64078f0a0f19dec3f50a178ffae7006b0a9ca58fb"
+      sha256: "831883fb353c8bdc1d71979e5b342c7d88acfbc643113c14ae51e2442ea0f20f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "0.17.3"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -550,6 +550,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.6.0"
+  flutter_html:
+    dependency: "direct main"
+    description:
+      name: flutter_html
+      sha256: "02ad69e813ecfc0728a455e4bf892b9379983e050722b1dce00192ee2e41d1ee"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0-beta.2"
   flutter_lints:
     dependency: "direct main"
     description:
@@ -1053,6 +1061,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  list_counter:
+    dependency: transitive
+    description:
+      name: list_counter
+      sha256: c447ae3dfcd1c55f0152867090e67e219d42fe6d4f2807db4bbe8b8d69912237
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -98,6 +98,7 @@ dependencies:
   firebase_remote_config: ^5.0.4
   carousel_slider: ^5.0.0
   smooth_page_indicator: ^1.2.0+3
+  flutter_html: ^3.0.0-beta.2
 
 dev_dependencies:
   build_runner:


### PR DESCRIPTION
This pull request adds the `flutter_html` package to the project, which allows for rendering HTML content. This package will be used to display static pages with rich content, such as the About Us, Terms and Conditions, License, and Contact Us pages.